### PR TITLE
fix(docker): clarify compose invocation contract

### DIFF
--- a/infra/docker/compose/README.md
+++ b/infra/docker/compose/README.md
@@ -22,3 +22,5 @@ Always call Docker Compose from repository root with:
 - one or more `-f infra/docker/compose/<file>.yml` arguments
 
 This keeps path resolution stable for build contexts, env-file references, and volume mounts across local, CI, and release workflows.
+
+Wrapper scripts may pass an absolute project directory (`--project-directory "$ROOT_DIR"`) and quoted compose file paths; that is equivalent and preferred inside scripted automation.


### PR DESCRIPTION
## Summary\n- clarify canonical compose invocation guidance in infra/docker/compose/README.md\n- document equivalence of absolute --project-directory usage in wrapper scripts\n\n## Why\n- keeps contributor guidance aligned with the scripted compose calls used in dev/down/smoke helpers\n- marks compose relocation follow-up as a patch-level user-facing fix for release automation