### PR TITLE
fix(ci): replace nightly marker git push with GitHub API variable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
 
@@ -112,7 +113,7 @@ jobs:
             exit 0
           fi
 
-          LAST_SHA=$(cat .sync/ci-main.sha 2>/dev/null || echo "")
+          LAST_SHA=$(gh variable get CI_NIGHTLY_LAST_SHA 2>/dev/null || echo "")
           if [ "$CURRENT_SHA" = "$LAST_SHA" ]; then
             echo "run_tests=false" >> "$GITHUB_OUTPUT"
             echo "run_postgres=false" >> "$GITHUB_OUTPUT"
@@ -176,7 +177,8 @@ jobs:
       matrix:
         database: [postgres, oracle]
     permissions:
-      contents: write
+      contents: read
+      actions: write
     services:
       postgres:
         image: postgres:17
@@ -349,18 +351,10 @@ jobs:
 
       - name: Update nightly CI marker
         if: github.event_name == 'schedule' && matrix.database == 'postgres'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          mkdir -p .sync
-          echo "${{ needs.detect.outputs.current_sha }}" > .sync/ci-main.sha
-          git add .sync/ci-main.sha
-          if git diff --cached --quiet; then
-            echo "No marker changes to commit."
-            exit 0
-          fi
-          git config user.name "enterpriseglue-ci-bot"
-          git config user.email "ci-bot@enterpriseglue.ai"
-          git commit -m "chore: update nightly CI marker"
-          git push origin HEAD:main
+          gh variable set CI_NIGHTLY_LAST_SHA --body "${{ needs.detect.outputs.current_sha }}"
 
   smoke-postgres-image-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

The nightly CI run fails at the 'Update nightly CI marker' step because branch protection now requires all changes to `main` go through a pull request. The step was doing `git push origin HEAD:main` to update `.sync/ci-main.sha`, which gets rejected with `GH006: Protected branch update failed`.

This cascades into `ci-complete` failing since it depends on `test (postgres)`.

## Fix

Replace the file-based marker (`.sync/ci-main.sha` + git push) with a **GitHub repository variable** (`CI_NIGHTLY_LAST_SHA`):

- **detect job**: reads via `gh variable get CI_NIGHTLY_LAST_SHA`
- **test job**: writes via `gh variable set CI_NIGHTLY_LAST_SHA` after successful nightly tests

This avoids any direct writes to the protected branch.

Also downgrades test job permissions from `contents:write` to `contents:read` + `actions:write` since we no longer push commits.

The repo variable has been seeded with the current marker value.