### PR TITLE
fix(ci): clear ENTRYPOINT in runtime contract verification for Chainguard node

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -141,7 +141,7 @@ jobs:
             -e FRONTEND_URL=http://localhost:8080
           )
 
-          docker run --rm \
+          docker run --rm --entrypoint '' \
             "${COMMON_ENV[@]}" \
             -e DATABASE_TYPE=postgres \
             -e POSTGRES_HOST=db \
@@ -153,7 +153,7 @@ jobs:
             "${{ steps.meta.outputs.backend_image }}:${{ steps.meta.outputs.image_tag }}" \
             node --input-type=module -e "import fs from 'fs'; const adapterPath=fs.existsSync('./dist/shared/db/adapters/index.js') ? './dist/shared/db/adapters/index.js' : './dist/src/shared/db/adapters/index.js'; const { createAdapter } = await import(adapterPath); const adapter=createAdapter('postgres'); const options=adapter.getDataSourceOptions(); if(options.type!=='postgres'){process.exit(1)} console.log('postgres runtime contract ok');"
 
-          docker run --rm \
+          docker run --rm --entrypoint '' \
             "${COMMON_ENV[@]}" \
             -e DATABASE_TYPE=oracle \
             -e ORACLE_HOST=db \
@@ -165,7 +165,7 @@ jobs:
             "${{ steps.meta.outputs.backend_image }}:${{ steps.meta.outputs.image_tag }}" \
             node --input-type=module -e "import fs from 'fs'; const adapterPath=fs.existsSync('./dist/shared/db/adapters/index.js') ? './dist/shared/db/adapters/index.js' : './dist/src/shared/db/adapters/index.js'; const { createAdapter } = await import(adapterPath); const adapter=createAdapter('oracle'); const options=adapter.getDataSourceOptions(); if(options.type!=='oracle'){process.exit(1)} console.log('oracle runtime contract ok');"
 
-          docker run --rm \
+          docker run --rm --entrypoint '' \
             "${COMMON_ENV[@]}" \
             -e DATABASE_TYPE=mysql \
             -e MYSQL_HOST=db \
@@ -176,7 +176,7 @@ jobs:
             "${{ steps.meta.outputs.backend_image }}:${{ steps.meta.outputs.image_tag }}" \
             node --input-type=module -e "import fs from 'fs'; const adapterPath=fs.existsSync('./dist/shared/db/adapters/index.js') ? './dist/shared/db/adapters/index.js' : './dist/src/shared/db/adapters/index.js'; const { createAdapter } = await import(adapterPath); const adapter=createAdapter('mysql'); const options=adapter.getDataSourceOptions(); if(options.type!=='mysql'){process.exit(1)} console.log('mysql runtime contract ok');"
 
-          docker run --rm \
+          docker run --rm --entrypoint '' \
             "${COMMON_ENV[@]}" \
             -e DATABASE_TYPE=mssql \
             -e MSSQL_HOST=db \
@@ -190,7 +190,7 @@ jobs:
             "${{ steps.meta.outputs.backend_image }}:${{ steps.meta.outputs.image_tag }}" \
             node --input-type=module -e "import fs from 'fs'; const adapterPath=fs.existsSync('./dist/shared/db/adapters/index.js') ? './dist/shared/db/adapters/index.js' : './dist/src/shared/db/adapters/index.js'; const { createAdapter } = await import(adapterPath); const adapter=createAdapter('mssql'); const options=adapter.getDataSourceOptions(); if(options.type!=='mssql'){process.exit(1)} console.log('mssql runtime contract ok');"
 
-          docker run --rm \
+          docker run --rm --entrypoint '' \
             "${COMMON_ENV[@]}" \
             -e DATABASE_TYPE=spanner \
             -e SPANNER_PROJECT_ID=test-project \


### PR DESCRIPTION
## Summary

Fixes the `Verify backend image runtime contract` step failing with `Cannot find module '/app/node'` in the `docker-images.yml` release workflow.

### Root cause

The Chainguard `node` base image sets `ENTRYPOINT ["node"]`. The runtime contract verification passes `node --input-type=module ...` as the docker run command, which becomes `node node --input-type=module ...` — hence the error.

### Fix

Added `--entrypoint ''` to all 5 `docker run` commands in the runtime contract verification step. This clears the entrypoint so the explicit `node` in the command works correctly.

### Impact

- Unblocks release v0.4.7 image publishing (failed at this step)
- Affects: postgres, oracle, mysql, mssql, spanner adapter contract checks