### PR TITLE
fix(ci): make nightly CI read-only by replacing mutable marker with API lookup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,8 +113,16 @@ jobs:
             exit 0
           fi
 
-          LAST_SHA=$(gh variable get CI_NIGHTLY_LAST_SHA 2>/dev/null || echo "")
-          if [ "$CURRENT_SHA" = "$LAST_SHA" ]; then
+          # Look up the HEAD SHA of the last successful scheduled CI run (read-only).
+          # This replaces the old mutable CI_NIGHTLY_LAST_SHA variable approach,
+          # removing the need for write permissions on Actions variables.
+          LAST_SHA=$(
+            gh api "repos/{owner}/{repo}/actions/workflows/ci.yml/runs?event=schedule&status=success&per_page=1" \
+              --jq '.workflow_runs[0].head_sha // ""' 2>/dev/null || echo ""
+          )
+          echo "last_successful_nightly_sha=$LAST_SHA" >> "$GITHUB_OUTPUT"
+
+          if [ -n "$LAST_SHA" ] && [ "$CURRENT_SHA" = "$LAST_SHA" ]; then
             echo "run_tests=false" >> "$GITHUB_OUTPUT"
             echo "run_postgres=false" >> "$GITHUB_OUTPUT"
             echo "run_oracle=false" >> "$GITHUB_OUTPUT"
@@ -178,7 +186,6 @@ jobs:
         database: [postgres, oracle]
     permissions:
       contents: read
-      actions: write
     services:
       postgres:
         image: postgres:17
@@ -349,12 +356,6 @@ jobs:
           name: frontend-coverage
           path: frontend/coverage
 
-      - name: Update nightly CI marker
-        if: github.event_name == 'schedule' && matrix.database == 'postgres'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh variable set CI_NIGHTLY_LAST_SHA --body "${{ needs.detect.outputs.current_sha }}"
 
   smoke-postgres-image-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Fixes the nightly CI schedule run failing every night with `HTTP 403: Resource not accessible by integration` on the `Update nightly CI marker` step, even though all actual tests pass.

### Root cause

The `test (postgres)` job had a schedule-only step that called `gh variable set CI_NIGHTLY_LAST_SHA`, which requires `actions: write` permission on the Actions variables API. The default `GITHUB_TOKEN` on scheduled runs does not have this permission, causing a 403. This step only ran on `schedule` events, so `workflow_dispatch` and `pull_request` runs were unaffected — hence the discrepancy.

### Fix

**Made CI fully read-only** with event parity:

1. **Replaced** mutable `gh variable get/set CI_NIGHTLY_LAST_SHA` with a read-only `gh api` call that fetches the last successful scheduled CI run's `head_sha`
2. **Removed** the `Update nightly CI marker` step from `test (postgres)`
3. **Dropped** `actions: write` permission from the test job

### Behavior

- Same skip-if-unchanged optimization for nightly runs
- No write side-effects in any CI path
- Schedule, dispatch, and PR runs now execute identical step sets (differing only in detection logic)
- No PAT or elevated token required