### PR TITLE
fix: expose auth middleware to enterprise plugin via app.locals

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,12 +1,18 @@
 import 'reflect-metadata';
 import { createApp, registerBaseRoutes, registerFinalMiddleware } from './app.js';
 import { config } from '@shared/config/index.js';
-import { initializeDatabase, ensureSchemaExists } from '@shared/db/run-migrations.js';
+import { ensureSchemaExists, initializeDatabase } from '@shared/db/run-migrations.js';
 import { bootstrapAdmin, backfillKnownUserProfiles, backfillMissingPlatformRoles } from '@shared/db/bootstrap.js';
+import { requireAuth } from '@shared/middleware/auth.js';
+import { requirePlatformAdmin } from '@shared/middleware/platformAuth.js';
 import { startBatchPoller } from './poller/batchPoller.js';
-import { getConnectionPool } from '@shared/db/db-pool.js';
+import { getConnectionPool, ConnectionPool } from '@shared/db/db-pool.js';
 import { loadEnterpriseBackendPlugin } from './enterprise/loadEnterpriseBackendPlugin.js';
 const app = createApp({ registerBaseRoutes: false, registerFinalMiddleware: false });
+
+// Expose middleware to enterprise plugin via app.locals
+app.locals.requireAuth = requireAuth;
+app.locals.requirePlatformAdmin = requirePlatformAdmin;
 
 const enterprisePlugin = await loadEnterpriseBackendPlugin();
 app.locals.enterprisePluginLoaded = Boolean(


### PR DESCRIPTION
## Summary

Adds `requireAuth` and `requirePlatformAdmin` to `app.locals` in `server.ts` so the enterprise backend plugin can access shared middleware without needing to modify this file.

### Why

This is the last shared file that diverges between OSS and EE due to EE-specific modifications. By adding these extension points to OSS, `server.ts` becomes byte-identical between repos, **permanently eliminating a sync conflict source**.

### Changes

- Import `requireAuth` and `requirePlatformAdmin` middleware
- Expose both via `app.locals` before plugin loading
- Import `ConnectionPool` type (needed by plugin API)
- Align import order with EE version

### Context

Part of the plugin architecture completion to make OSS → EE sync conflict-free. See also: enterpriseglue-the-bridge-ee#16 (sync workflow conflict handling).