### PR TITLE
fix(security): bump minimatch override to ^10.2.4

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -76,7 +76,7 @@
     "esbuild": "^0.27.2",
     "cookie": "^0.7.0",
     "lodash": "^4.17.23",
-    "minimatch": "^10.2.1",
+    "minimatch": "^10.2.4",
     "cross-spawn": "^7.0.6",
     "glob": "^10.5.0",
     "tar": "^7.5.8",


### PR DESCRIPTION
## Summary
- bump backend minimatch override from ^10.2.1 to ^10.2.4
- addresses CVE-2026-27903 and CVE-2026-27904 findings from backend Trivy scan

## Validation
- rebuilt backend prod image locally
- rescanned HIGH/CRITICAL with Trivy: TOTAL_FINDINGS=0