### PR TITLE
fix(ci): trigger release-please on push to main

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,6 +1,9 @@
 name: Release Please
 
 on:
+  push:
+    branches:
+      - main
   schedule:
     - cron: "30 3 * * *"
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- add push trigger for main to release-please workflow
- ensures a merged release PR is finalized into a published GitHub release without waiting for schedule/manual dispatch

## Why
- hotfix flow can create and auto-merge release PRs, but publication was delayed until next release-please run

## Validation
- workflow syntax change only