### PR TITLE
fix(ci): resolve Docker publish deadlock and add CVE details to nightly reports

### DIFF
--- a/.github/workflows/docker-images-reusable.yml
+++ b/.github/workflows/docker-images-reusable.yml
@@ -57,10 +57,6 @@ permissions:
   contents: read
   packages: write
 
-concurrency:
-  group: docker-images-${{ github.ref }}
-  cancel-in-progress: false
-
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/security-nightly-reusable.yml
+++ b/.github/workflows/security-nightly-reusable.yml
@@ -29,6 +29,34 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # -- Validate image freshness ---------------------------------------------
+
+      - name: Validate scanned image versions
+        id: image-meta
+        shell: bash
+        run: |
+          set -euo pipefail
+          backend_ref="${{ inputs.backend_image_ref }}"
+          frontend_ref="${{ inputs.frontend_image_ref }}"
+
+          backend_digest="$(docker manifest inspect "$backend_ref" -v 2>/dev/null | jq -r '.[0].Descriptor.digest // .config.digest // "unknown"' 2>/dev/null || echo 'unavailable')"
+          frontend_digest="$(docker manifest inspect "$frontend_ref" -v 2>/dev/null | jq -r '.[0].Descriptor.digest // .config.digest // "unknown"' 2>/dev/null || echo 'unavailable')"
+
+          backend_version="$(docker manifest inspect "$backend_ref" -v 2>/dev/null | jq -r '.[0].OCIManifest.annotations["org.opencontainers.image.version"] // .[0].Descriptor.annotations["org.opencontainers.image.version"] // "unknown"' 2>/dev/null || echo 'unknown')"
+          frontend_version="$(docker manifest inspect "$frontend_ref" -v 2>/dev/null | jq -r '.[0].OCIManifest.annotations["org.opencontainers.image.version"] // .[0].Descriptor.annotations["org.opencontainers.image.version"] // "unknown"' 2>/dev/null || echo 'unknown')"
+
+          echo "backend_digest=${backend_digest}" >> "$GITHUB_OUTPUT"
+          echo "frontend_digest=${frontend_digest}" >> "$GITHUB_OUTPUT"
+          echo "backend_version=${backend_version}" >> "$GITHUB_OUTPUT"
+          echo "frontend_version=${frontend_version}" >> "$GITHUB_OUTPUT"
+
+          echo "### Scanned image metadata" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Image | Ref | Version | Digest |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|---|---|---|---|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| backend | \`${backend_ref}\` | ${backend_version} | \`${backend_digest:0:20}…\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| frontend | \`${frontend_ref}\` | ${frontend_version} | \`${frontend_digest:0:20}…\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
       # -- Trivy scans --------------------------------------------------------
 
       - name: Trivy scan backend image
@@ -163,6 +191,17 @@ jobs:
               echo "| Low | ${low} |" >> "$GITHUB_STEP_SUMMARY"
               echo "| **Total** | **${count}** |" >> "$GITHUB_STEP_SUMMARY"
               echo "" >> "$GITHUB_STEP_SUMMARY"
+
+              if [ "$count" -gt 0 ]; then
+                echo "<details><summary>Vulnerability details</summary>" >> "$GITHUB_STEP_SUMMARY"
+                echo "" >> "$GITHUB_STEP_SUMMARY"
+                echo "| CVE | Package | Severity | Installed | Fixed |" >> "$GITHUB_STEP_SUMMARY"
+                echo "|---|---|---|---|---|" >> "$GITHUB_STEP_SUMMARY"
+                jq -r '[.Results[]?.Vulnerabilities // [] | .[] | "| \(.VulnerabilityID) | \(.PkgName) | \(.Severity) | \(.InstalledVersion) | \(.FixedVersion // "none") |"] | .[]' "$file" >> "$GITHUB_STEP_SUMMARY"
+                echo "" >> "$GITHUB_STEP_SUMMARY"
+                echo "</details>" >> "$GITHUB_STEP_SUMMARY"
+                echo "" >> "$GITHUB_STEP_SUMMARY"
+              fi
             fi
           done
 
@@ -190,6 +229,10 @@ jobs:
             body += `**Run:** [${process.env.GITHUB_RUN_ID}](${runUrl})\n`;
             body += `**Date:** ${new Date().toISOString().split('T')[0]}\n`;
             body += `**Total findings:** ${total}\n\n`;
+            body += `### Scanned images\n\n`;
+            body += `| Image | Ref | Version | Digest |\n|---|---|---|---|\n`;
+            body += `| backend | \`${{ inputs.backend_image_ref }}\` | ${{ steps.image-meta.outputs.backend_version }} | \`${{ steps.image-meta.outputs.backend_digest }}\` |\n`;
+            body += `| frontend | \`${{ inputs.frontend_image_ref }}\` | ${{ steps.image-meta.outputs.frontend_version }} | \`${{ steps.image-meta.outputs.frontend_digest }}\` |\n\n`;
             body += ${{ toJSON(steps.evaluate.outputs.body) }};
 
             if (hasExpired) {


### PR DESCRIPTION
## Problem

### 1. v0.4.11 Docker Images workflow failed → stale `:latest`

Between v0.4.10 and v0.4.11, the Docker publish logic was extracted into `docker-images-reusable.yml`. Both the caller and the reusable workflow declared the **same concurrency group**:

```yaml
concurrency:
  group: docker-images-${{ github.ref }}
  cancel-in-progress: false
```

When the caller acquires this group, the reusable workflow's `publish` job tries to enter the same group → **deadlock**. The job never starts, all downstream jobs skip, run marked as failure. v0.4.10 worked because it had everything inline (single concurrency context).

**Result:** `:latest` still points to the pre-fix image → nightly security scan reports stale CVEs.

### 2. Security nightly step summary missing CVE details

The CVE detail table was only in the GitHub issue body (inside a collapsed `<details>` block). The Actions UI step summary only showed severity count tables — no actual CVE IDs.

### 3. No image version validation in nightly scan

The nightly scan had no way to detect it was scanning a stale `:latest` image. If a Docker publish fails (like this case), the scan silently reports findings against an old image.

## Fix

- **Remove duplicate concurrency group** from `docker-images-reusable.yml` (the caller already manages concurrency)
- **Add CVE detail table** to the step summary in `security-nightly-reusable.yml`
- **Add image version/digest metadata** to both step summary and issue body so stale `:latest` is immediately identifiable

## After merge

1. Re-run Docker Images workflow for v0.4.11 to publish the fixed image and update `:latest`
2. Re-run security-nightly to verify issue #46 auto-closes