### PR TITLE
fix: gracefully handle enterprise plugin on non-postgres databases

### DIFF
--- a/backend/__tests__/enterprise/loadEnterpriseBackendPlugin.test.ts
+++ b/backend/__tests__/enterprise/loadEnterpriseBackendPlugin.test.ts
@@ -38,10 +38,16 @@ describe('loadEnterpriseBackendPlugin validation helpers', () => {
     }).not.toThrow();
   });
 
-  it('returns noop plugin when enterprise package is unavailable (OSS mode)', async () => {
+  it('returns a valid plugin (noop in OSS, real in EE)', async () => {
     const plugin = await loadEnterpriseBackendPlugin();
 
-    expect(plugin.registerRoutes).toBeUndefined();
-    expect(plugin.migrateEnterpriseDatabase).toBeUndefined();
+    // In OSS mode the hooks are undefined (noop); in EE mode they are functions.
+    // Both shapes are valid – assert no broken exports.
+    if (plugin.registerRoutes !== undefined) {
+      expect(typeof plugin.registerRoutes).toBe('function');
+    }
+    if (plugin.migrateEnterpriseDatabase !== undefined) {
+      expect(typeof plugin.migrateEnterpriseDatabase).toBe('function');
+    }
   });
 });

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -25,14 +25,25 @@ console.log(
 );
 
 try {
-  // Pass database-agnostic connection pool to enterprise plugin
-  await enterprisePlugin.registerRoutes?.(app as any, {
-    connectionPool: getConnectionPool(),
-    config,
-  } as any);
+  // Pass database-agnostic connection pool to enterprise plugin.
+  // getConnectionPool() only supports postgres today; on other db types
+  // we skip enterprise route registration gracefully.
+  if (enterprisePlugin.registerRoutes) {
+    const pool = getConnectionPool();
+    await enterprisePlugin.registerRoutes(app as any, {
+      connectionPool: pool,
+      config,
+    } as any);
+  }
 } catch (error) {
-  console.error('Failed to register enterprise routes:', error);
-  throw error;
+  // If the pool isn't implemented for this database type, log and continue
+  // without enterprise routes rather than crashing the server.
+  if (error instanceof Error && error.message.includes('ConnectionPool raw SQL adapter is not implemented')) {
+    console.warn(`[Enterprise] Skipping enterprise routes: ${error.message}`);
+  } else {
+    console.error('Failed to register enterprise routes:', error);
+    throw error;
+  }
 }
 
 registerBaseRoutes(app);
@@ -57,8 +68,12 @@ if (enterprisePlugin.migrateEnterpriseDatabase) {
       config,
     } as any);
   } catch (error) {
-    console.error('Failed to run enterprise migrations:', error);
-    throw error;
+    if (error instanceof Error && error.message.includes('ConnectionPool raw SQL adapter is not implemented')) {
+      console.warn(`[Enterprise] Skipping enterprise migrations: ${error.message}`);
+    } else {
+      console.error('Failed to run enterprise migrations:', error);
+      throw error;
+    }
   }
 }
 


### PR DESCRIPTION
- Update loadEnterpriseBackendPlugin test to accept both noop (OSS) and real plugin (EE) modes
- Gracefully skip enterprise route registration and migrations when the database type doesn't support raw SQL connection pools (e.g. Oracle)
- Required by EE PR #34 (git submodule approach) where the enterprise plugin now loads successfully