### PR TITLE
fix: always grant platform admin role to bootstrap user

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -77,11 +77,13 @@ if (enterprisePlugin.migrateEnterpriseDatabase) {
   }
 }
 
-// Bootstrap admin account on first run
-await bootstrapAdmin({ allowPlatformAdmin: !app.locals.enterprisePluginLoaded });
+// Bootstrap admin account on first run.
+// Always grant platform admin to the bootstrap user — the EE plugin can
+// layer its own tenant-level role management on top.
+await bootstrapAdmin({ allowPlatformAdmin: true });
 await backfillMissingPlatformRoles();
 
-await backfillKnownUserProfiles({ allowPlatformAdmin: !app.locals.enterprisePluginLoaded });
+await backfillKnownUserProfiles({ allowPlatformAdmin: true });
 
 // Seed Git providers on first run
 try {


### PR DESCRIPTION
When enterprisePluginLoaded was true, allowPlatformAdmin was set to false, causing the bootstrap admin to get 'user' role instead of 'admin'. This broke E2E tests and any fresh deployment where the first user needs admin access.

The EE plugin manages tenant-level roles separately, so the platform bootstrap admin should always be 'admin'.

Required by EE PR #34 (git submodule approach).