### PR TITLE
fix: gitignore node_modules symlinks (drop trailing slash)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Node / TypeScript
-node_modules/
+node_modules
 *.log
 npm-debug.log*
 yarn-debug.log*

--- a/backend/scripts/resolve-dist-imports.mjs
+++ b/backend/scripts/resolve-dist-imports.mjs
@@ -10,10 +10,8 @@
  */
 import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join, dirname, relative } from 'node:path';
-import { fileURLToPath } from 'node:url';
 
-const scriptDir = dirname(fileURLToPath(import.meta.url));
-const distDir = join(scriptDir, '..', 'dist');
+const distDir = join(process.cwd(), 'dist');
 
 // Alias prefix → corresponding directory inside the dist tree
 const aliases = [


### PR DESCRIPTION
The `node_modules/` pattern (with trailing slash) only matches directories, not symlinks to directories. When the OSS repo is consumed as a submodule in EE, `setup-oss-submodule.sh` creates symlinks for `backend/node_modules` and `frontend/node_modules`. These slip through the gitignore and show as untracked files. Removing the trailing slash makes the pattern match both real directories and symlinks.