### PR TITLE
chore: fix publish workflow dependency installation

### DIFF
--- a/.github/workflows/publish-backend-host.yml
+++ b/.github/workflows/publish-backend-host.yml
@@ -37,9 +37,15 @@ jobs:
           registry-url: https://npm.pkg.github.com
           scope: "@enterpriseglue"
 
-      - name: Install dependencies
+      - name: Install shared dependencies
+        run: npm ci
+        working-directory: packages/shared
+
+      - name: Install backend-host dependencies
         run: npm install
-        working-directory: .
+
+      - name: Link shared node_modules for transitive type resolution
+        run: ln -s "$PWD/packages/shared/node_modules" packages/node_modules
 
       - name: Build shared (dependency)
         run: npm run build

--- a/.github/workflows/publish-shared.yml
+++ b/.github/workflows/publish-shared.yml
@@ -38,8 +38,7 @@ jobs:
           scope: "@enterpriseglue"
 
       - name: Install dependencies
-        run: npm install
-        working-directory: .
+        run: npm ci
 
       - name: Build package
         run: npm run build


### PR DESCRIPTION
The publish workflows were running `npm install` at the root level, which only installs root deps (simple-git, @playwright/test). The shared and backend-host packages need their own dependencies installed for the build to succeed.

**Changes:**
- `publish-shared.yml`: Use `npm ci` in packages/shared (has lockfile) instead of root `npm install`
- `publish-backend-host.yml`: Install shared deps (`npm ci`), backend-host deps (`npm install`), and symlink `packages/node_modules → shared/node_modules` for transitive type resolution (express, typeorm, etc.)