### PR TITLE
chore: use backend deps in publish workflows for full type resolution

### DIFF
--- a/.github/workflows/publish-backend-host.yml
+++ b/.github/workflows/publish-backend-host.yml
@@ -37,15 +37,13 @@ jobs:
           registry-url: https://npm.pkg.github.com
           scope: "@enterpriseglue"
 
-      - name: Install shared dependencies
+      - name: Install backend dependencies
         run: npm ci
-        working-directory: packages/shared
+        working-directory: backend
 
-      - name: Install backend-host dependencies
-        run: npm install
-
-      - name: Link shared node_modules for transitive type resolution
-        run: ln -s "$PWD/packages/shared/node_modules" packages/node_modules
+      - name: Link backend node_modules for package resolution
+        run: ln -s "$PWD/backend/node_modules" packages/node_modules
+        working-directory: .
 
       - name: Build shared (dependency)
         run: npm run build

--- a/.github/workflows/publish-shared.yml
+++ b/.github/workflows/publish-shared.yml
@@ -37,8 +37,13 @@ jobs:
           registry-url: https://npm.pkg.github.com
           scope: "@enterpriseglue"
 
-      - name: Install dependencies
+      - name: Install backend dependencies
         run: npm ci
+        working-directory: backend
+
+      - name: Link backend node_modules for shared package resolution
+        run: ln -s "$PWD/backend/node_modules" packages/node_modules
+        working-directory: .
 
       - name: Build package
         run: npm run build


### PR DESCRIPTION
Follow-up to PR #76. The shared package source imports packages (octokit, bitbucket, azure-devops-node-api, @asteasolutions/zod-to-openapi) that live in the backend's package.json, not the shared package's own deps. This mirrors the local dev setup where `packages/node_modules → backend/node_modules`.

**Changes:**
- `publish-shared.yml`: Install backend deps + symlink `packages/node_modules → backend/node_modules`
- `publish-backend-host.yml`: Same pattern (replaces shared-only install)