### PR TITLE
fix(deps): patch CVE-2026-27601 and CVE-2026-3449

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -70,7 +70,38 @@
     "../packages/shared": {
       "name": "@enterpriseglue/shared",
       "version": "0.1.0",
-      "dev": true
+      "dev": true,
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "bcryptjs": "^3.0.3",
+        "cookie-parser": "^1.4.7",
+        "cors": "^2.8.5",
+        "dotenv": "^17.2.3",
+        "express": "^4.19.2",
+        "express-rate-limit": "^8.2.1",
+        "helmet": "^8.1.0",
+        "jsonwebtoken": "^9.0.2",
+        "nodemailer": "^7.0.12",
+        "oracledb": "^6.0.0",
+        "pg": "^8.11.3",
+        "resend": "^6.4.1",
+        "typeorm": "^0.3.28",
+        "undici": "^7.18.2",
+        "uuid": "^11.1.0",
+        "zod": "^3.23.8"
+      },
+      "devDependencies": {
+        "@types/bcryptjs": "^2.4.6",
+        "@types/cookie-parser": "^1.4.7",
+        "@types/cors": "^2.8.17",
+        "@types/express": "^4.17.21",
+        "@types/jsonwebtoken": "^9.0.6",
+        "@types/node": "^22.16.0",
+        "@types/nodemailer": "^6.4.17",
+        "@types/pg": "^8.11.6",
+        "@types/uuid": "^10.0.0",
+        "typescript": "^5.8.3"
+      }
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
@@ -7825,9 +7856,9 @@
       }
     },
     "node_modules/underscore": {
-      "version": "1.13.7",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
-      "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
       "license": "MIT"
     },
     "node_modules/undici": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -85,6 +85,8 @@
     "brace-expansion": "^2.0.2",
     "diff": "^5.2.2",
     "fast-xml-parser": "^5.3.6",
-    "qs": "^6.14.2"
+    "qs": "^6.14.2",
+    "underscore": "^1.13.8",
+    "@tootallnate/once": "^3.0.1"
   }
 }


### PR DESCRIPTION
Resolves #80

## Changes
- Override `underscore` to `>=1.13.8` (CVE-2026-27601: DoS via unlimited recursion in `_.flatten`/`_.isEqual`)
- Override `@tootallnate/once` to `>=3.0.1` (CVE-2026-3449: promise hangs with AbortSignal)

Both are transitive deps pulled in by `azure-devops-node-api` → `typed-rest-client` → `underscore`, and optional DB drivers in the Docker build stage respectively.

## Verification
- `npm ls underscore` confirms 1.13.8
- Typecheck passes