### PR TITLE
fix(ci): add actions:read permission to CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,6 +12,7 @@ on:
 permissions:
   security-events: write
   contents: read
+  actions: read
 
 concurrency:
   group: codeql-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
CodeQL action needs `actions:read` to check workflow run status during SARIF upload.