### PR TITLE
fix(ci): make ci-core-reusable.yml build step generic for OSS and EE

### DIFF
--- a/.github/workflows/ci-core-reusable.yml
+++ b/.github/workflows/ci-core-reusable.yml
@@ -181,15 +181,19 @@ jobs:
         if: matrix.database == 'postgres' && steps.pw-cache.outputs.cache-hit == 'true'
         run: npx playwright install-deps
 
-      - name: Build OSS packages
+      - name: Build local packages
         run: |
-          # Conditionally build monorepo packages (OSS has these; EE does not)
-          if [ -f packages/shared/package.json ]; then
-            npm --prefix packages/shared run build
-          fi
-          if [ -f packages/backend-host/package.json ]; then
-            npm --prefix packages/backend-host run build
-          fi
+          # Auto-discover and build any packages/*/ that have a "build" script.
+          # OSS: packages/shared, packages/backend-host
+          # EE:  packages/enterprise-backend, packages/enterprise-frontend
+          for pkg in packages/*/package.json; do
+            [ -f "$pkg" ] || continue
+            dir="$(dirname "$pkg")"
+            if node -e "const p=require('./${pkg}'); process.exit(p.scripts?.build ? 0 : 1)" 2>/dev/null; then
+              echo "Building $dir ..."
+              npm --prefix "$dir" run build
+            fi
+          done
 
       - name: Build backend
         run: npm --prefix backend run build:skip-generate


### PR DESCRIPTION
Replace hardcoded OSS package builds with auto-discovery loop that builds any `packages/*/` with a `build` script.

**Root cause:** EE's merge queue CI failed because the build step only knew about OSS's `packages/shared` and `packages/backend-host`. EE has `packages/enterprise-backend` and `packages/enterprise-frontend` which also need building.

**Fix:** Generic loop discovers and builds all local packages automatically. Works for both repos without any caller-side changes.