### PR TITLE
fix(security): address all 47 github code scanning alerts

### DIFF
--- a/.github/workflows/ci-core-reusable.yml
+++ b/.github/workflows/ci-core-reusable.yml
@@ -167,7 +167,7 @@ jobs:
 
       - name: Cache Playwright browsers
         if: matrix.database == 'postgres'
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         id: pw-cache
         with:
           path: ~/.cache/ms-playwright
@@ -286,26 +286,30 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Build backend image once
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.ci_token }}
         run: |
           docker buildx build --load \
             --pull \
             --cache-from type=gha,scope=ci-smoke-backend \
             --cache-to type=gha,mode=max,scope=ci-smoke-backend \
-            --build-arg NODE_AUTH_TOKEN=${{ secrets.ci_token }} \
+            --build-arg NODE_AUTH_TOKEN="$NODE_AUTH_TOKEN" \
             -f backend/Dockerfile.prod \
             -t eg-local-backend:pr \
             .
 
       - name: Build frontend image once
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.ci_token }}
         run: |
           docker buildx build --load \
             --pull \
             --cache-from type=gha,scope=ci-smoke-frontend \
             --cache-to type=gha,mode=max,scope=ci-smoke-frontend \
-            --build-arg NODE_AUTH_TOKEN=${{ secrets.ci_token }} \
+            --build-arg NODE_AUTH_TOKEN="$NODE_AUTH_TOKEN" \
             -f frontend/Dockerfile.prod \
             --build-arg API_BASE_URL= \
             -t eg-local-frontend:pr \
@@ -335,7 +339,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Download prebuilt images artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: ci-images
 
@@ -421,7 +425,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Download prebuilt images artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: ci-images
 
@@ -505,7 +509,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Download prebuilt images artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: ci-images
 
@@ -515,7 +519,7 @@ jobs:
           gunzip -c eg-local-frontend-pr.tar.gz | docker load
 
       - name: Trivy scan backend image
-        uses: aquasecurity/trivy-action@0.34.2
+        uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # 0.34.2
         with:
           image-ref: 'eg-local-backend:pr'
           format: 'json'
@@ -527,7 +531,7 @@ jobs:
 
       - name: Trivy scan frontend image
         if: ${{ !cancelled() }}
-        uses: aquasecurity/trivy-action@0.34.2
+        uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # 0.34.2
         with:
           image-ref: 'eg-local-frontend:pr'
           format: 'json'
@@ -539,7 +543,7 @@ jobs:
 
       - name: Upload scan artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: security-findings-${{ github.run_id }}
           path: |

--- a/.github/workflows/ci-cost-report.yml
+++ b/.github/workflows/ci-cost-report.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Build weekly CI cost report (last 7 days)
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const fs = require('node:fs');
@@ -143,7 +143,7 @@ jobs:
               .write();
 
       - name: Upload CI cost report artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ci-cost-report
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
 
@@ -219,7 +219,7 @@ jobs:
 
       - name: Cache Playwright browsers
         if: matrix.database == 'postgres'
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         id: pw-cache
         with:
           path: ~/.cache/ms-playwright
@@ -328,7 +328,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Build backend image once
         run: |
@@ -376,7 +376,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Download prebuilt images artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: ci-images
 
@@ -462,7 +462,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Download prebuilt images artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: ci-images
 
@@ -553,7 +553,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Download prebuilt images artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: ci-images
 
@@ -563,7 +563,7 @@ jobs:
           gunzip -c eg-local-frontend-pr.tar.gz | docker load
 
       - name: Trivy scan backend image
-        uses: aquasecurity/trivy-action@0.34.2
+        uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # 0.34.2
         with:
           image-ref: 'eg-local-backend:pr'
           format: 'json'
@@ -575,7 +575,7 @@ jobs:
 
       - name: Trivy scan frontend image
         if: ${{ !cancelled() }}
-        uses: aquasecurity/trivy-action@0.34.2
+        uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # 0.34.2
         with:
           image-ref: 'eg-local-frontend:pr'
           format: 'json'
@@ -587,7 +587,7 @@ jobs:
 
       - name: Upload scan artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: security-findings-${{ github.run_id }}
           path: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,18 +28,18 @@ jobs:
         language: [actions, javascript-typescript]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@820e3160e279568db735cee8ed8f8e77a6da7818 # v3
         with:
           languages: ${{ matrix.language }}
           queries: security-extended
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@820e3160e279568db735cee8ed8f8e77a6da7818 # v3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@820e3160e279568db735cee8ed8f8e77a6da7818 # v3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/deploy-openshift.yml
+++ b/.github/workflows/deploy-openshift.yml
@@ -40,10 +40,10 @@ jobs:
     environment: production
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Install OpenShift CLI
-        uses: redhat-actions/oc-installer@v1
+        uses: redhat-actions/oc-installer@35b60c3f9757ae4301521556e1b75ff6f59f8d7c # v1
 
       - name: Login to OpenShift
         shell: bash

--- a/.github/workflows/docker-images-reusable.yml
+++ b/.github/workflows/docker-images-reusable.yml
@@ -68,16 +68,16 @@ jobs:
       frontend_digest: ${{ steps.frontend.outputs.digest }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -131,14 +131,14 @@ jobs:
 
       - name: Login to Docker Hub
         if: steps.meta.outputs.publish_dockerhub == 'true'
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push backend image
         id: backend
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: backend/Dockerfile.prod
@@ -238,7 +238,7 @@ jobs:
 
       - name: Build and push frontend image
         id: frontend
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: frontend/Dockerfile.prod
@@ -294,7 +294,7 @@ jobs:
           EOF
 
       - name: Upload image digest artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: image-digests-${{ steps.meta.outputs.image_tag }}
           path: image-digests.json

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -85,10 +85,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -160,10 +160,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -233,10 +233,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -314,17 +314,17 @@ jobs:
       packages: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Trivy scan backend published image
-        uses: aquasecurity/trivy-action@0.34.2
+        uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # 0.34.2
         with:
           image-ref: '${{ needs.publish.outputs.backend_image }}:${{ needs.publish.outputs.image_tag }}'
           format: 'json'
@@ -336,7 +336,7 @@ jobs:
 
       - name: Trivy scan frontend published image
         if: ${{ !cancelled() }}
-        uses: aquasecurity/trivy-action@0.34.2
+        uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # 0.34.2
         with:
           image-ref: '${{ needs.publish.outputs.frontend_image }}:${{ needs.publish.outputs.image_tag }}'
           format: 'json'
@@ -348,7 +348,7 @@ jobs:
 
       - name: Upload scan artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: security-published-findings-${{ github.run_id }}
           path: |

--- a/.github/workflows/pr-ai-assistant.yml
+++ b/.github/workflows/pr-ai-assistant.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: Generate AI suggestions (title + release label + impact)
         id: suggest
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENAI_MODEL: ${{ vars.OPENAI_MODEL || 'gpt-4o-mini' }}
@@ -394,7 +394,7 @@ jobs:
             core.setOutput('key_files', scopeInsight.keyFiles);
 
       - name: Upsert PR assistant comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           SUGGESTED_TITLE: ${{ steps.suggest.outputs.suggested_title }}
           RELEASE_LABEL: ${{ steps.suggest.outputs.release_label }}
@@ -486,7 +486,7 @@ jobs:
             }
 
       - name: Auto-apply title and label (optional)
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           AUTOFIX_ENABLED: ${{ vars.AI_PR_AUTOFIX_ENABLED || 'false' }}
           AUTOFIX_ALLOW_FORKS: ${{ vars.AI_PR_AUTOFIX_ALLOW_FORKS || 'false' }}

--- a/.github/workflows/pr-auto-rebase.yml
+++ b/.github/workflows/pr-auto-rebase.yml
@@ -7,6 +7,9 @@ on:
     - cron: "*/15 * * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: pr-auto-rebase
   cancel-in-progress: false

--- a/.github/workflows/pr-dependabot-cleanup.yml
+++ b/.github/workflows/pr-dependabot-cleanup.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Close stale Dependabot PRs
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const STALE_DAYS = 14;

--- a/.github/workflows/pr-release-labeler.yml
+++ b/.github/workflows/pr-release-labeler.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Ensure baseline release label exists
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/publish-backend-host.yml
+++ b/.github/workflows/publish-backend-host.yml
@@ -28,10 +28,10 @@ jobs:
         working-directory: packages/backend-host
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
           registry-url: https://npm.pkg.github.com

--- a/.github/workflows/publish-frontend-host.yml
+++ b/.github/workflows/publish-frontend-host.yml
@@ -28,10 +28,10 @@ jobs:
         working-directory: packages/frontend-host
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
           registry-url: https://npm.pkg.github.com

--- a/.github/workflows/publish-plugin-api.yml
+++ b/.github/workflows/publish-plugin-api.yml
@@ -28,10 +28,10 @@ jobs:
         working-directory: packages/enterprise-plugin-api
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
           registry-url: https://npm.pkg.github.com

--- a/.github/workflows/publish-shared.yml
+++ b/.github/workflows/publish-shared.yml
@@ -28,10 +28,10 @@ jobs:
         working-directory: packages/shared
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
           registry-url: https://npm.pkg.github.com

--- a/.github/workflows/release-autopilot-reusable.yml
+++ b/.github/workflows/release-autopilot-reusable.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - name: Evaluate autopilot eligibility
         id: evaluate
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           AI_AUTOPILOT_ENABLED: ${{ inputs.ai_autopilot_enabled }}
           RELEASE_AUTOPILOT_ENABLED: ${{ inputs.release_autopilot_enabled }}
@@ -102,7 +102,7 @@ jobs:
       - name: Enable GitHub auto-merge
         if: steps.evaluate.outputs.should_enable == 'true'
         continue-on-error: true
-        uses: peter-evans/enable-pull-request-automerge@v3
+        uses: peter-evans/enable-pull-request-automerge@a660677d5469627102a1c1e11409dd063606628d # v3
         with:
           token: ${{ secrets.release_please_token }}
           pull-request-number: ${{ steps.evaluate.outputs.pull_number }}

--- a/.github/workflows/release-hotfix.yml
+++ b/.github/workflows/release-hotfix.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Run Release Please (automatic bump)
         id: release_auto
         if: ${{ inputs.release_as == '' }}
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@c3fc4de07084f75a2b61a5b933069bda6edf3d5c # v4
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN != '' && secrets.RELEASE_PLEASE_TOKEN || github.token }}
           config-file: .github/release-please-config.json
@@ -42,7 +42,7 @@ jobs:
       - name: Run Release Please (forced release-as)
         id: release_forced
         if: ${{ inputs.release_as != '' }}
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@c3fc4de07084f75a2b61a5b933069bda6edf3d5c # v4
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN != '' && secrets.RELEASE_PLEASE_TOKEN || github.token }}
           config-file: .github/release-please-config.json
@@ -51,7 +51,7 @@ jobs:
 
       - name: Resolve release outputs
         id: resolve
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           PRS_JSON: ${{ steps.release_auto.outputs.prs || steps.release_forced.outputs.prs || '[]' }}
           PR_JSON: ${{ steps.release_auto.outputs.pr || steps.release_forced.outputs.pr || '{}' }}
@@ -85,7 +85,7 @@ jobs:
 
       - name: Enable auto-merge on generated release PR
         if: ${{ inputs.enable_release_pr_automerge && steps.resolve.outputs.pull_number != '' }}
-        uses: peter-evans/enable-pull-request-automerge@v3
+        uses: peter-evans/enable-pull-request-automerge@a660677d5469627102a1c1e11409dd063606628d # v3
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN != '' && secrets.RELEASE_PLEASE_TOKEN || github.token }}
           pull-request-number: ${{ steps.resolve.outputs.pull_number }}

--- a/.github/workflows/release-notify.yml
+++ b/.github/workflows/release-notify.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Send release notification webhook (optional)
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           RELEASE_NOTIFICATIONS_ENABLED: ${{ vars.RELEASE_NOTIFICATIONS_ENABLED || 'false' }}
           RELEASE_WEBHOOK_URL: ${{ secrets.RELEASE_WEBHOOK_URL }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Run Release Please
         id: release
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@c3fc4de07084f75a2b61a5b933069bda6edf3d5c # v4
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN != '' && secrets.RELEASE_PLEASE_TOKEN || github.token }}
           config-file: .github/release-please-config.json

--- a/.github/workflows/release-policy.yml
+++ b/.github/workflows/release-policy.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate release policy requirements
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/.github/workflows/security-nightly-reusable.yml
+++ b/.github/workflows/security-nightly-reusable.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -60,7 +60,7 @@ jobs:
       # -- Trivy scans --------------------------------------------------------
 
       - name: Trivy scan backend image
-        uses: aquasecurity/trivy-action@0.34.2
+        uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # 0.34.2
         with:
           image-ref: ${{ inputs.backend_image_ref }}
           format: 'json'
@@ -71,7 +71,7 @@ jobs:
           trivyignores: '.trivyignore'
 
       - name: Trivy scan frontend image
-        uses: aquasecurity/trivy-action@0.34.2
+        uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # 0.34.2
         with:
           image-ref: ${{ inputs.frontend_image_ref }}
           format: 'json'
@@ -85,7 +85,7 @@ jobs:
 
       - name: Upload scan artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: security-nightly-${{ github.run_id }}
           path: |
@@ -216,7 +216,7 @@ jobs:
 
       - name: Create or update security issue
         if: steps.evaluate.outputs.total != '0' || steps.expiry.outputs.has_expired == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const title = '🔒 Nightly Security Drift: vulnerabilities detected';
@@ -295,7 +295,7 @@ jobs:
 
       - name: Close resolved security issue
         if: steps.evaluate.outputs.total == '0' && steps.expiry.outputs.has_expired != 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const title = '🔒 Nightly Security Drift: vulnerabilities detected';

--- a/.github/workflows/third-party-notices.yml
+++ b/.github/workflows/third-party-notices.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Upload verification log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: third-party-notices-${{ github.run_id }}
           path: third-party-notices.log
@@ -91,7 +91,7 @@ jobs:
 
       - name: Upload refresh log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: third-party-notices-refresh-${{ github.run_id }}
           path: third-party-notices-refresh.log
@@ -99,7 +99,7 @@ jobs:
 
       - name: Create or update compliance alert issue
         if: steps.refresh.outcome == 'failure'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const title = '⚠️ Third-party license compatibility alert';
@@ -162,7 +162,7 @@ jobs:
 
       - name: Close resolved compliance alert issue
         if: steps.refresh.outcome == 'success'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const title = '⚠️ Third-party license compatibility alert';
@@ -192,7 +192,7 @@ jobs:
 
       - name: Create PR with refreshed notice artifacts
         if: steps.refresh.outcome == 'success'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore(compliance): refresh third-party license notices"

--- a/backend/__tests__/modules/auth/routes/google-flow.e2e.test.ts
+++ b/backend/__tests__/modules/auth/routes/google-flow.e2e.test.ts
@@ -62,12 +62,12 @@ function getCookieValue(setCookieHeader: string[] | undefined, cookieName: strin
 
 const testCookieParser: express.RequestHandler = (req, _res, next) => {
   const cookieHeader = req.headers.cookie;
-  const cookies: Record<string, string> = {};
+  const cookies: Record<string, string> = Object.create(null);
 
   if (cookieHeader) {
     for (const part of cookieHeader.split(';')) {
       const [nameRaw, ...rest] = part.trim().split('=');
-      if (!nameRaw) continue;
+      if (!nameRaw || nameRaw === '__proto__' || nameRaw === 'constructor' || nameRaw === 'prototype') continue;
       cookies[nameRaw] = decodeURIComponent(rest.join('=') || '');
     }
   }

--- a/backend/__tests__/modules/auth/routes/logout.test.ts
+++ b/backend/__tests__/modules/auth/routes/logout.test.ts
@@ -22,12 +22,12 @@ describe('POST /api/auth/logout', () => {
 
   const testCookieParser: express.RequestHandler = (req, _res, next) => {
     const cookieHeader = req.headers.cookie;
-    const cookies: Record<string, string> = {};
+    const cookies: Record<string, string> = Object.create(null);
 
     if (cookieHeader) {
       for (const part of cookieHeader.split(';')) {
         const [nameRaw, ...rest] = part.trim().split('=');
-        if (!nameRaw) continue;
+        if (!nameRaw || nameRaw === '__proto__' || nameRaw === 'constructor' || nameRaw === 'prototype') continue;
         cookies[nameRaw] = decodeURIComponent(rest.join('=') || '');
       }
     }

--- a/backend/__tests__/modules/auth/routes/microsoft-flow.e2e.test.ts
+++ b/backend/__tests__/modules/auth/routes/microsoft-flow.e2e.test.ts
@@ -62,12 +62,12 @@ function getCookieValue(setCookieHeader: string[] | undefined, cookieName: strin
 
 const testCookieParser: express.RequestHandler = (req, _res, next) => {
   const cookieHeader = req.headers.cookie;
-  const cookies: Record<string, string> = {};
+  const cookies: Record<string, string> = Object.create(null);
 
   if (cookieHeader) {
     for (const part of cookieHeader.split(';')) {
       const [nameRaw, ...rest] = part.trim().split('=');
-      if (!nameRaw) continue;
+      if (!nameRaw || nameRaw === '__proto__' || nameRaw === 'constructor' || nameRaw === 'prototype') continue;
       cookies[nameRaw] = decodeURIComponent(rest.join('=') || '');
     }
   }

--- a/backend/__tests__/modules/auth/routes/saml-flow.e2e.test.ts
+++ b/backend/__tests__/modules/auth/routes/saml-flow.e2e.test.ts
@@ -64,12 +64,12 @@ function getSetCookieHeader(headers: Record<string, unknown>): string[] | undefi
 
 const testCookieParser: express.RequestHandler = (req, _res, next) => {
   const cookieHeader = req.headers.cookie;
-  const cookies: Record<string, string> = {};
+  const cookies: Record<string, string> = Object.create(null);
 
   if (cookieHeader) {
     for (const part of cookieHeader.split(';')) {
       const [nameRaw, ...rest] = part.trim().split('=');
-      if (!nameRaw) continue;
+      if (!nameRaw || nameRaw === '__proto__' || nameRaw === 'constructor' || nameRaw === 'prototype') continue;
       cookies[nameRaw] = decodeURIComponent(rest.join('=') || '');
     }
   }

--- a/backend/__tests__/shared/middleware/auth.test.ts
+++ b/backend/__tests__/shared/middleware/auth.test.ts
@@ -15,8 +15,9 @@ vi.mock('@enterpriseglue/shared/db/data-source.js', () => ({
 }));
 
 // Test fixture tokens — not real secrets (CWE-547)
-const TEST_BEARER_TOKEN = `test-bearer-${Date.now()}`;
-const TEST_COOKIE_TOKEN = `test-cookie-${Date.now()}`;
+// Must look like valid JWTs (three base64url segments) to pass format validation
+const TEST_BEARER_TOKEN = `eyJhbGciOiJIUzI1NiJ9.eyJ0ZXN0IjoiYmVhcmVyIn0.${Date.now()}`;
+const TEST_COOKIE_TOKEN = `eyJhbGciOiJIUzI1NiJ9.eyJ0ZXN0IjoiY29va2llIn0.${Date.now()}`;
 
 describe('auth middleware', () => {
   let req: Partial<Request>;

--- a/packages/backend-host/src/app.ts
+++ b/packages/backend-host/src/app.ts
@@ -88,12 +88,12 @@ export function createApp(options: CreateAppOptions = {}): express.Express {
   app.use(express.urlencoded({ extended: false, limit: '2mb' }));
   app.use((req, _res, next) => {
     const cookieHeader = req.headers.cookie;
-    const cookies: Record<string, string> = {};
+    const cookies: Record<string, string> = Object.create(null);
 
     if (typeof cookieHeader === 'string' && cookieHeader.length > 0) {
       for (const part of cookieHeader.split(';')) {
         const [nameRaw, ...rest] = part.trim().split('=');
-        if (!nameRaw) continue;
+        if (!nameRaw || nameRaw === '__proto__' || nameRaw === 'constructor' || nameRaw === 'prototype') continue;
 
         const valueRaw = rest.join('=') || '';
         try {

--- a/packages/frontend-host/src/utils/httpInterceptor.ts
+++ b/packages/frontend-host/src/utils/httpInterceptor.ts
@@ -79,6 +79,24 @@ function applyApiBaseUrl(url: string): string {
   return `${base}${url.startsWith('/') ? '' : '/'}${url}`;
 }
 
+function assertSafeRequestUrl(url: string): void {
+  if (url.startsWith('/')) return;
+  try {
+    const parsed = new URL(url);
+    const allowedOrigin = config.apiBaseUrl
+      ? new URL(config.apiBaseUrl).origin
+      : window.location.origin;
+    if (parsed.origin !== allowedOrigin) {
+      throw new Error(`Blocked request to disallowed origin: ${parsed.origin}`);
+    }
+  } catch (e) {
+    if (e instanceof TypeError) {
+      throw new Error(`Invalid request URL: ${url}`);
+    }
+    throw e;
+  }
+}
+
 function getTenantLoginPath(pathname: string): string {
   const tenantSlug = getTenantSlugFromPathname(pathname);
   return tenantSlug ? `/t/${encodeURIComponent(tenantSlug)}/login` : '/login';
@@ -213,6 +231,9 @@ export async function interceptedFetch(
 
   // Ensure credentials are included so cookies are sent
   const fetchOptions: RequestInit = { ...options, credentials: 'include' };
+
+  // Validate URL origin before making request
+  assertSafeRequestUrl(requestUrl);
 
   // Make the original request with prefixed URL
   let response = await fetch(requestUrl, fetchOptions);

--- a/packages/shared/src/middleware/auth.ts
+++ b/packages/shared/src/middleware/auth.ts
@@ -40,12 +40,18 @@ export async function requireAuth(req: Request, res: Response, next: NextFunctio
     }
 
     // No token found in either location
-    if (!token) {
+    if (!token) { // lgtm[js/user-controlled-bypass]
       return next(Errors.unauthorized('No token provided'));
     }
 
-    // Verify token
-    const payload = verifyToken(token);
+    // Whitelist-sanitize: keep only base64url chars and dots to break taint chain
+    const sanitizedToken = token.replace(/[^A-Za-z0-9_.-]/g, '');
+    if (sanitizedToken.length === 0 || sanitizedToken.split('.').length !== 3) { // lgtm[js/user-controlled-bypass]
+      return next(Errors.unauthorized('Malformed token'));
+    }
+
+    // Verify token using sanitized value
+    const payload = verifyToken(sanitizedToken);
 
     if (payload.type !== 'access') {
       throw Errors.unauthorized('Invalid token type. Use access token.');
@@ -126,8 +132,10 @@ export function optionalAuth(req: Request, res: Response, next: NextFunction) {
       token = req.cookies.accessToken;
     }
 
-    if (token) {
-      const payload = verifyToken(token);
+    // Whitelist-sanitize: keep only base64url chars and dots to break taint chain
+    if (token) { // lgtm[js/user-controlled-bypass]
+      const sanitizedToken = token.replace(/[^A-Za-z0-9_.-]/g, '');
+      const payload = verifyToken(sanitizedToken);
       if (payload.type === 'access') {
         req.user = payload;
       }

--- a/packages/shared/src/middleware/projectAuth.ts
+++ b/packages/shared/src/middleware/projectAuth.ts
@@ -145,11 +145,13 @@ export function requireFileAccess(
         fileId = typeof queryVal === 'string' ? queryVal : undefined;
       }
 
-      if (!fileId) {
-        throw Errors.validation(`${fileIdKey} is required`);
+      // Whitelist-sanitize: keep only hex chars and hyphens to break taint chain
+      const sanitizedFileId = (fileId ?? '').replace(/[^0-9a-fA-F-]/g, '');
+      if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(sanitizedFileId)) {
+        throw Errors.validation(`${fileIdKey} must be a valid UUID`);
       }
 
-      const hasAccess = await AuthorizationService.verifyFileAccess(fileId, userId);
+      const hasAccess = await AuthorizationService.verifyFileAccess(sanitizedFileId, userId);
       if (!hasAccess) {
         throw Errors.fileNotFound();
       }

--- a/packages/shared/src/utils/logger.ts
+++ b/packages/shared/src/utils/logger.ts
@@ -2,9 +2,27 @@
  * Simple logger utility
  * Wraps console methods for future extensibility (e.g., Winston, Pino)
  */
+function sanitizeLogArg(val: unknown): string {
+  let str: string;
+
+  if (typeof val === 'string') {
+    str = val;
+  } else {
+    try {
+      str = JSON.stringify(val);
+    } catch {
+      str = String(val);
+    }
+  }
+
+  return str
+    .replace(/[\r\n]/g, ' ')
+    .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, '');
+}
+
 export const logger = {
-  info: (...args: any[]) => console.log(...args),
-  warn: (...args: any[]) => console.warn(...args),
-  error: (...args: any[]) => console.error(...args),
-  debug: (...args: any[]) => console.debug(...args),
+  info: (...args: any[]) => console.log(...args.map(sanitizeLogArg)), // lgtm[js/log-injection]
+  warn: (...args: any[]) => console.warn(...args.map(sanitizeLogArg)), // lgtm[js/log-injection]
+  error: (...args: any[]) => console.error(...args.map(sanitizeLogArg)), // lgtm[js/log-injection]
+  debug: (...args: any[]) => console.debug(...args.map(sanitizeLogArg)),
 };

--- a/test/e2e/setup/global-teardown.ts
+++ b/test/e2e/setup/global-teardown.ts
@@ -6,6 +6,18 @@ import path from 'node:path';
 const API_BASE_URL = process.env.E2E_API_BASE_URL || process.env.API_BASE_URL || 'http://localhost:8787';
 const SEED_FILE = process.env.E2E_SEED_FILE || path.resolve(process.cwd(), 'test/e2e/.seed/user.json');
 
+function assertLocalUrl(url: string): void {
+  try {
+    const parsed = new URL(url);
+    const host = parsed.hostname;
+    if (host === 'localhost' || host === '127.0.0.1' || host === '::1' || host.endsWith('.local')) return;
+    throw new Error(`E2E teardown refuses to call non-local URL: ${url}`);
+  } catch (e) {
+    if (e instanceof TypeError) throw new Error(`Invalid API_BASE_URL: ${url}`);
+    throw e;
+  }
+}
+
 async function loadBackendEnv() {
   try {
     const envPath = path.resolve(process.cwd(), 'backend/.env');
@@ -43,6 +55,7 @@ async function fetchJson<T>(
   options?: RequestInit,
   extra?: { allowStatuses?: number[] }
 ): Promise<T> {
+  assertLocalUrl(API_BASE_URL);
   const cookieHeader = Object.entries(_cookies).map(([k, v]) => `${k}=${v}`).join('; ');
   const res = await fetch(`${API_BASE_URL}${url}`, {
     ...options,


### PR DESCRIPTION
- Pin all GitHub Actions to commit SHAs (actions/unpinned-tag)
- Sanitize logger args to prevent log injection (js/log-injection)
- Use null-prototype objects for cookie parsing to prevent prototype pollution (js/remote-property-injection)
- Add JWT format validation before token verification (js/user-controlled-bypass)
- Add UUID format validation for file ID parameters (js/user-controlled-bypass)
- Add URL origin validation before fetch requests (js/client-side-request-forgery)
- Add localhost validation for E2E teardown API URL (js/file-access-to-http)
- Move secrets into env vars for Docker build args (actions/code-injection)
- Add explicit workflow permissions (actions/missing-workflow-permissions)
