### PR TITLE
fix(ci): install backend deps separately when not a workspace

### DIFF
--- a/.github/workflows/ci-core-reusable.yml
+++ b/.github/workflows/ci-core-reusable.yml
@@ -150,15 +150,21 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.ci_token }}
 
+      - name: Install backend dependencies
+        run: |
+          # EE: backend/ is standalone (not a workspace) and has its own lock file
+          # OSS: backend/ is a workspace, already installed by root npm ci
+          if [ -f backend/package-lock.json ]; then
+            npm ci --prefix backend
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.ci_token }}
+
       - name: Install DB driver for matrix database
         if: matrix.database == 'oracle'
         run: |
-          # Use workspace flag if 'backend' workspace exists, otherwise install at root
-          if npm -w backend --version >/dev/null 2>&1; then
-            npm -w backend install --no-save oracledb
-          else
-            npm install --no-save oracledb
-          fi
+          # Install oracledb in backend — use --prefix since backend may not be a workspace
+          npm --prefix backend install --no-save oracledb
 
       - name: Get Playwright version
         if: matrix.database == 'postgres'


### PR DESCRIPTION
**Root cause:** In EE, `backend/` is standalone with its own `package-lock.json` — root `npm ci` doesn't install its dependencies (including `@enterpriseglue/backend-host`). In OSS, `backend/` is a workspace so root `npm ci` covers it.

**Fix:** Conditional `npm ci --prefix backend` when `backend/package-lock.json` exists. Also simplifies oracle driver install to use `--prefix` consistently.