### PR TITLE
fix(ci): install standalone backend/frontend deps for EE compat

### DIFF
--- a/.github/workflows/ci-core-reusable.yml
+++ b/.github/workflows/ci-core-reusable.yml
@@ -150,13 +150,16 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.ci_token }}
 
-      - name: Install backend dependencies
+      - name: Install standalone directory dependencies
         run: |
-          # EE: backend/ is standalone (not a workspace) and has its own lock file
-          # OSS: backend/ is a workspace, already installed by root npm ci
-          if [ -f backend/package-lock.json ]; then
-            npm ci --prefix backend
-          fi
+          # EE: backend/ and frontend/ are standalone (not workspaces) with own lock files
+          # OSS: they are workspaces, already installed by root npm ci
+          for dir in backend frontend; do
+            if [ -f "$dir/package-lock.json" ]; then
+              echo "Installing $dir/ deps (standalone, not a workspace)..."
+              npm ci --prefix "$dir"
+            fi
+          done
         env:
           NODE_AUTH_TOKEN: ${{ secrets.ci_token }}
 


### PR DESCRIPTION
**Root cause:** In EE, `backend/` and `frontend/` are standalone directories (not npm workspaces) with their own `package-lock.json`. The root `npm ci` only installs root + workspace deps, leaving `backend/node_modules` and `frontend/node_modules` empty.

**Symptoms:**
- `@enterpriseglue/backend-host` not found during backend TypeScript build
- `@vitejs/plugin-react` not found during frontend vitest run

**Fix:** Auto-detect and install standalone directory deps via `npm ci --prefix` when a lock file exists. No-op for OSS where these are workspaces.