### PR TITLE
fix(frontend-host): use dist/ exports directly, add build step to Dockerfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,6 +237,7 @@ jobs:
         run: |
           npm --prefix packages/shared run build
           npm --prefix packages/backend-host run build
+          npm run build:frontend-host
 
       - name: Build backend
         run: npm --prefix backend run build:skip-generate

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -20,7 +20,8 @@ RUN apk upgrade --no-cache \
 
 COPY frontend frontend
 COPY packages packages
-RUN npm -w frontend run build \
+RUN npm run --prefix packages/frontend-host build \
+    && npm -w frontend run build \
     && mkdir -p /tmp/busybox-bin \
     && cp /bin/busybox.static /tmp/busybox-bin/busybox \
     && ln -s busybox /tmp/busybox-bin/sh \

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "deploy:openshift:skip-health": "SKIP_EXTERNAL_HEALTHCHECK=true bash ./scripts/deploy-openshift.sh",
     "deploy:localhost": "bash ./scripts/deploy-localhost.sh",
     "build": "ENV_FILE=.local/docker/env/docker.env; [ -f \"$ENV_FILE\" ] || ENV_FILE=.env.docker; EG_BACKEND_ENV_FILE=\"$ENV_FILE\" docker compose --project-directory . --env-file \"$ENV_FILE\" -f infra/docker/compose/docker-compose.yml build",
+    "build:frontend-host": "npm run --prefix packages/frontend-host build",
     "typecheck": "npm --prefix backend run typecheck && npm --prefix frontend run typecheck",
     "test:unit": "npm --prefix backend run test:unit && npm --prefix frontend run test:unit",
     "test:integration": "npm --prefix backend run test:integration",

--- a/packages/frontend-host/package.json
+++ b/packages/frontend-host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@enterpriseglue/frontend-host",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "OSS frontend host for EnterpriseGlue — routes, enterprise loader, extension registry, and feature components",
   "license": "AGPL-3.0-or-later",
   "repository": {
@@ -29,20 +29,16 @@
     "assets/**/*"
   ],
   "exports": {
-    "./*": "./src/*",
+    "./*": {
+      "types": "./dist/*.d.ts",
+      "default": "./dist/*.js"
+    },
+    "./styles/*": "./dist/styles/*",
     "./assets/*": "./assets/*"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com",
-    "access": "restricted",
-    "exports": {
-      "./*": {
-        "types": "./dist/*.d.ts",
-        "default": "./dist/*.js"
-      },
-      "./styles/*": "./dist/styles/*",
-      "./assets/*": "./assets/*"
-    }
+    "access": "restricted"
   },
   "devDependencies": {
     "typescript": "~5.9.3",


### PR DESCRIPTION
publishConfig.exports is not applied by npm to the published tarball.
Exports must point to dist/ directly for both workspace and registry use.

- exports: ./* → dist/*.js (was ./src/* with broken publishConfig override)
- Dockerfile.prod: build frontend-host before frontend vite build
- Root package.json: add build:frontend-host convenience script
- Bump to 0.3.1
