### PR TITLE
chore(ci): add canary dispatch + shared proxy routes

### DIFF
--- a/.github/workflows/publish-backend-host.yml
+++ b/.github/workflows/publish-backend-host.yml
@@ -91,6 +91,21 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Notify EE canary
+        if: >-
+          !(github.event_name == 'workflow_dispatch' && inputs.dry_run == 'true')
+          && steps.check.outcome != 'success'
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.EE_DISPATCH_TOKEN }}
+          repository: EnterpriseGlue/enterpriseglue-the-bridge-ee
+          event-type: oss-package-published
+          client-payload: |
+            {
+              "package_name": "${{ steps.pkg.outputs.name }}",
+              "package_version": "${{ steps.pkg.outputs.version }}"
+            }
+
       - name: Summary
         run: |
           echo "### Backend Host Published :package:" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-frontend-host.yml
+++ b/.github/workflows/publish-frontend-host.yml
@@ -91,6 +91,19 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Notify EE canary
+        if: steps.check.outcome != 'success'
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.EE_DISPATCH_TOKEN }}
+          repository: EnterpriseGlue/enterpriseglue-the-bridge-ee
+          event-type: oss-package-published
+          client-payload: |
+            {
+              "package_name": "${{ steps.pkg.outputs.name }}",
+              "package_version": "${{ steps.pkg.outputs.version }}"
+            }
+
       - name: Summary
         run: |
           echo "### Frontend Host Published :package:" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-shared.yml
+++ b/.github/workflows/publish-shared.yml
@@ -87,6 +87,21 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Notify EE canary
+        if: >-
+          !(github.event_name == 'workflow_dispatch' && inputs.dry_run == 'true')
+          && steps.check.outcome != 'success'
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.EE_DISPATCH_TOKEN }}
+          repository: EnterpriseGlue/enterpriseglue-the-bridge-ee
+          event-type: oss-package-published
+          client-payload: |
+            {
+              "package_name": "${{ steps.pkg.outputs.name }}",
+              "package_version": "${{ steps.pkg.outputs.version }}"
+            }
+
       - name: Summary
         run: |
           echo "### Shared Package Published :package:" >> "$GITHUB_STEP_SUMMARY"

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,9 +1,44 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'node:path'
+import { createRequire } from 'node:module'
 
 export default defineConfig(({ mode }) => {
   const proxyTarget = (globalThis as any).process?.env?.DEV_PROXY_TARGET || 'http://localhost:8787'
+
+  const require = createRequire(import.meta.url)
+  let proxyPatterns = [
+    '^/t/[^/]+/api',
+    '^/t/[^/]+/engines-api',
+    '^/t/[^/]+/starbase-api',
+    '^/t/[^/]+/mission-control-api',
+    '^/t/[^/]+/git-api',
+    '^/t/[^/]+/vcs-api',
+    '^/t/[^/]+/health',
+    '/api',
+    '/engines-api',
+    '/starbase-api',
+    '/mission-control-api',
+    '/git-api',
+    '/vcs-api',
+    '/health',
+  ]
+  try {
+    const proxyConfig = require('@enterpriseglue/frontend-host/proxy-routes.json') as {
+      proxyPatterns: string[]
+    }
+    if (proxyConfig?.proxyPatterns?.length) {
+      proxyPatterns = proxyConfig.proxyPatterns
+    }
+  } catch (error) {
+    console.warn('Using fallback proxy routes (proxy-routes.json not found).')
+  }
+  const proxyRoutes = Object.fromEntries(
+    proxyPatterns.map((pattern) => [
+      pattern,
+      { target: proxyTarget, changeOrigin: true },
+    ]),
+  )
 
   // Expose feature flags to frontend via import.meta.env
   const multiTenant = (globalThis as any).process?.env?.MULTI_TENANT
@@ -34,124 +69,10 @@ export default defineConfig(({ mode }) => {
         // Allow images including data URIs (inline SVGs)
         'Content-Security-Policy': "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://1.www.s81c.com; font-src 'self' data: https://fonts.gstatic.com https://1.www.s81c.com; img-src 'self' data: blob: https:; connect-src 'self' http://localhost:8787;",
       },
-      proxy: {
-        '^/t/[^/]+/api': {
-          target: proxyTarget,
-          changeOrigin: true,
-        },
-        '^/t/[^/]+/engines-api': {
-          target: proxyTarget,
-          changeOrigin: true,
-        },
-        '^/t/[^/]+/starbase-api': {
-          target: proxyTarget,
-          changeOrigin: true,
-        },
-        '^/t/[^/]+/mission-control-api': {
-          target: proxyTarget,
-          changeOrigin: true,
-        },
-        '^/t/[^/]+/git-api': {
-          target: proxyTarget,
-          changeOrigin: true,
-        },
-        '^/t/[^/]+/vcs-api': {
-          target: proxyTarget,
-          changeOrigin: true,
-        },
-        '^/t/[^/]+/health': {
-          target: proxyTarget,
-          changeOrigin: true,
-        },
-        '/api': {
-          target: proxyTarget,
-          changeOrigin: true,
-        },
-        '/engines-api': {
-          target: proxyTarget,
-          changeOrigin: true,
-        },
-        '/starbase-api': {
-          target: proxyTarget,
-          changeOrigin: true,
-        },
-        '/mission-control-api': {
-          target: proxyTarget,
-          changeOrigin: true,
-        },
-        '/git-api': {
-          target: proxyTarget,
-          changeOrigin: true,
-        },
-        '/vcs-api': {
-          target: proxyTarget,
-          changeOrigin: true,
-        },
-        '/health': {
-          target: proxyTarget,
-          changeOrigin: true,
-        },
-      },
+      proxy: proxyRoutes,
     },
     preview: {
-      proxy: {
-        '^/t/[^/]+/api': {
-          target: proxyTarget,
-          changeOrigin: true,
-        },
-        '^/t/[^/]+/engines-api': {
-          target: proxyTarget,
-          changeOrigin: true,
-        },
-        '^/t/[^/]+/starbase-api': {
-          target: proxyTarget,
-          changeOrigin: true,
-        },
-        '^/t/[^/]+/mission-control-api': {
-          target: proxyTarget,
-          changeOrigin: true,
-        },
-        '^/t/[^/]+/git-api': {
-          target: proxyTarget,
-          changeOrigin: true,
-        },
-        '^/t/[^/]+/vcs-api': {
-          target: proxyTarget,
-          changeOrigin: true,
-        },
-        '^/t/[^/]+/health': {
-          target: proxyTarget,
-          changeOrigin: true,
-        },
-        '/api': {
-          target: proxyTarget,
-          changeOrigin: true,
-        },
-        '/engines-api': {
-          target: proxyTarget,
-          changeOrigin: true,
-        },
-        '/starbase-api': {
-          target: proxyTarget,
-          changeOrigin: true,
-        },
-        '/mission-control-api': {
-          target: proxyTarget,
-          changeOrigin: true,
-        },
-        '/git-api': {
-          target: proxyTarget,
-          changeOrigin: true,
-        },
-        '/vcs-api': {
-          target: proxyTarget,
-          changeOrigin: true,
-        },
-        '/health': {
-          target: proxyTarget,
-          changeOrigin: true,
-        },
-      },
+      proxy: proxyRoutes,
     },
   }
 })

--- a/packages/frontend-host/package.json
+++ b/packages/frontend-host/package.json
@@ -26,6 +26,7 @@
     "src/**/*.svg",
     "src/**/*.png",
     "src/**/*.d.ts",
+    "proxy-routes.json",
     "assets/**/*"
   ],
   "exports": {
@@ -33,6 +34,7 @@
       "types": "./dist/*.d.ts",
       "default": "./dist/*.js"
     },
+    "./proxy-routes.json": "./proxy-routes.json",
     "./styles/*": "./dist/styles/*",
     "./assets/*": "./assets/*"
   },

--- a/packages/frontend-host/proxy-routes.json
+++ b/packages/frontend-host/proxy-routes.json
@@ -1,0 +1,18 @@
+{
+  "proxyPatterns": [
+    "^/t/[^/]+/api",
+    "^/t/[^/]+/engines-api",
+    "^/t/[^/]+/starbase-api",
+    "^/t/[^/]+/mission-control-api",
+    "^/t/[^/]+/git-api",
+    "^/t/[^/]+/vcs-api",
+    "^/t/[^/]+/health",
+    "/api",
+    "/engines-api",
+    "/starbase-api",
+    "/mission-control-api",
+    "/git-api",
+    "/vcs-api",
+    "/health"
+  ]
+}


### PR DESCRIPTION
## Summary\n- add shared proxy-routes.json in frontend-host and consume in OSS Vite config\n- dispatch EE canary workflow after OSS package publishes\n\n## Testing\n- not run (workflow/config change only)