### PR TITLE
chore(compliance): refresh third-party license notices

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -2,7 +2,7 @@
 
 This project includes software developed by third parties. The following notices are provided for attribution purposes.
 
-Generated at: 2026-03-08T05:41:38.587Z
+Generated at: 2026-03-09T05:56:36.025Z
 
 Generated from:
 - third_party_licenses.json


### PR DESCRIPTION
Automated refresh of third-party notice artifacts.

Generated by:
- `bash ./scripts/update-third-party-notices.sh --strict`