### PR TITLE
chore(ci): add 7-day retention to CI artifacts and caches

### DIFF
--- a/.github/workflows/ci-core-reusable.yml
+++ b/.github/workflows/ci-core-reusable.yml
@@ -191,6 +191,7 @@ jobs:
           key: playwright-${{ runner.os }}-${{ steps.pw-version.outputs.version }}-${{ hashFiles('package-lock.json', 'backend/package-lock.json', 'frontend/package-lock.json') }}
           restore-keys: |
             playwright-${{ runner.os }}-${{ steps.pw-version.outputs.version }}-
+          retention-days: 7
 
       - name: Install Playwright browsers
         if: matrix.database == 'postgres' && inputs.run_e2e && steps.pw-cache.outputs.cache-hit != 'true'
@@ -285,18 +286,20 @@ jobs:
         run: npm --prefix backend run db:cleanup-test-data
 
       - name: Upload backend coverage
-        if: matrix.database == 'postgres'
+        if: failure() && matrix.database == 'postgres'
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: backend-coverage
           path: backend/coverage
+          retention-days: 7
 
       - name: Upload frontend coverage
-        if: matrix.database == 'postgres'
+        if: failure() && matrix.database == 'postgres'
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: frontend-coverage
           path: frontend/coverage
+          retention-days: 7
 
   build-ci-images:
     runs-on: ubuntu-latest
@@ -350,6 +353,7 @@ jobs:
           path: |
             eg-local-backend-pr.tar.gz
             eg-local-frontend-pr.tar.gz
+          retention-days: 7
 
   smoke-postgres-image-deploy:
     runs-on: ubuntu-latest
@@ -573,6 +577,7 @@ jobs:
             backend-trivy.json
             frontend-trivy.json
           if-no-files-found: warn
+          retention-days: 7
 
       - name: Security scan summary
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,7 @@ jobs:
           path: .artifacts/
           if-no-files-found: error
           include-hidden-files: true
+          retention-days: 7
 
   compose-render:
     runs-on: ubuntu-latest
@@ -252,6 +253,7 @@ jobs:
           key: playwright-${{ runner.os }}-${{ steps.pw-version.outputs.version }}-${{ hashFiles('package-lock.json', 'backend/package-lock.json', 'frontend/package-lock.json') }}
           restore-keys: |
             playwright-${{ runner.os }}-${{ steps.pw-version.outputs.version }}-
+          retention-days: 7
 
       - name: Install Playwright browsers
         if: matrix.database == 'postgres' && steps.pw-cache.outputs.cache-hit != 'true'
@@ -333,18 +335,20 @@ jobs:
         run: npm --prefix backend run db:cleanup-test-data
 
       - name: Upload backend coverage
-        if: matrix.database == 'postgres' && github.event_name != 'merge_group'
+        if: failure() && matrix.database == 'postgres' && github.event_name != 'merge_group'
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: backend-coverage
           path: backend/coverage
+          retention-days: 7
 
       - name: Upload frontend coverage
-        if: matrix.database == 'postgres' && github.event_name != 'merge_group'
+        if: failure() && matrix.database == 'postgres' && github.event_name != 'merge_group'
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: frontend-coverage
           path: frontend/coverage
+          retention-days: 7
 
   build-ci-images:
     runs-on: ubuntu-latest
@@ -392,6 +396,7 @@ jobs:
           path: |
             eg-local-backend-pr.tar.gz
             eg-local-frontend-pr.tar.gz
+          retention-days: 7
 
 
   smoke-postgres-image-deploy:
@@ -623,6 +628,7 @@ jobs:
             backend-trivy.json
             frontend-trivy.json
           if-no-files-found: warn
+          retention-days: 7
 
       - name: Security scan summary
         if: always()

--- a/.github/workflows/docker-images-reusable.yml
+++ b/.github/workflows/docker-images-reusable.yml
@@ -444,6 +444,7 @@ jobs:
           name: image-digests-${{ steps.meta.outputs.image_tag }}
           path: image-digests.json
           if-no-files-found: error
+          retention-days: 7
 
       - name: Verify multi-arch manifest coverage
         shell: bash

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -155,6 +155,7 @@ jobs:
           path: |
             test/results/
           if-no-files-found: warn
+          retention-days: 7
 
   smoke-postgres-image-deploy-exposed:
     needs: publish
@@ -357,6 +358,7 @@ jobs:
             backend-trivy.json
             frontend-trivy.json
           if-no-files-found: warn
+          retention-days: 7
 
       - name: Security scan summary
         if: always()


### PR DESCRIPTION
Add 7-day retention policies to all artifact and cache uploads in CI workflows to reduce GitHub Actions storage consumption.

Changes:
- Add retention-days: 7 to all actions/upload-artifact steps
- Add retention-days: 7 to all actions/cache steps
- Coverage artifacts now only upload on test failure

Files modified:
- .github/workflows/ci.yml
- .github/workflows/docker-images.yml
- .github/workflows/ci-core-reusable.yml
- .github/workflows/docker-images-reusable.yml

Expected impact: 60-70% reduction in GitHub Actions storage usage. Old artifacts will expire automatically after 7 days from the next workflow run.

Manual step required: Set workflow log retention to 30 days in repo settings (Settings -> Actions -> General).