### PR TITLE
fix(frontend-host): route tenant admin settings to EE page

### DIFF
--- a/packages/frontend-host/package.json
+++ b/packages/frontend-host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@enterpriseglue/frontend-host",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "OSS frontend host for EnterpriseGlue — routes, enterprise loader, extension registry, and feature components",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/frontend-host/src/features/shared/components/LayoutWithProSidebar.tsx
+++ b/packages/frontend-host/src/features/shared/components/LayoutWithProSidebar.tsx
@@ -779,9 +779,9 @@ export default function LayoutWithProSidebar() {
                     {getNavItemsBySection('admin').map((item: NavExtension) => (
                       <HeaderMenuItem
                         key={item.id}
-                        href={item.path}
+                        href={toTenantPath(item.path)}
                         isCurrentPage={effectivePathname === item.path || effectivePathname.startsWith(`${item.path}/`)}
-                        onClick={(e) => { e.preventDefault(); navigate(item.path); (document.activeElement as HTMLElement)?.blur() }}
+                        onClick={(e) => { e.preventDefault(); navigate(toTenantPath(item.path)); (document.activeElement as HTMLElement)?.blur() }}
                       >
                         {item.label}
                       </HeaderMenuItem>

--- a/packages/frontend-host/src/routes/index.tsx
+++ b/packages/frontend-host/src/routes/index.tsx
@@ -145,7 +145,11 @@ export function createProtectedChildRoutes(isRootLevel: boolean): RouteObject[] 
     // Admin routes
     ...((!multiTenantEnabled || !isRootLevel) ? [{
       path: `${pathPrefix}admin/settings`, 
-      element: (
+      element: multiTenantEnabled && !isRootLevel ? (
+        <ProtectedRoute requireAdmin={false}>
+          <ExtensionPage name="tenant-settings-page" />
+        </ProtectedRoute>
+      ) : (
         <ProtectedRoute requireAdmin>
           <LazyRoute message="Loading settings...">
             <PlatformSettingsPage />
@@ -153,7 +157,7 @@ export function createProtectedChildRoutes(isRootLevel: boolean): RouteObject[] 
         </ProtectedRoute>
       )
     }] : []),
-    ...((!multiTenantEnabled || !isRootLevel) ? [
+    ...(!multiTenantEnabled ? [
       {
         path: `${pathPrefix}admin/settings/git`,
         element: (
@@ -194,6 +198,12 @@ export function createProtectedChildRoutes(isRootLevel: boolean): RouteObject[] 
           </ProtectedRoute>
         )
       },
+    ] : []),
+    ...(multiTenantEnabled && !isRootLevel ? [
+      { path: `${pathPrefix}admin/settings/git`, element: <Navigate to="../admin/settings" replace /> },
+      { path: `${pathPrefix}admin/settings/projects`, element: <Navigate to="../admin/settings" replace /> },
+      { path: `${pathPrefix}admin/settings/engines`, element: <Navigate to="../admin/settings" replace /> },
+      { path: `${pathPrefix}admin/settings/sso`, element: <Navigate to="../admin/settings" replace /> },
     ] : []),
     { 
       path: `${pathPrefix}admin/sso-mappings`, 


### PR DESCRIPTION
## Summary
- render the EE tenant settings extension for /t/:tenantSlug/admin/settings in multi-tenant mode
- keep enterprise Admin nav links tenant-prefixed
- redirect old tenant-scoped /admin/settings/* platform tabs back to tenant settings so they do not call EE-disabled global settings APIs
- bump @enterpriseglue/frontend-host to 0.4.4

## Verification
- corepack pnpm@11.0.8 --filter @enterpriseglue/frontend-host run typecheck
- corepack pnpm@11.0.8 --filter webmodeler-frontend run test:unit -- frontend/__tests__/src/routes/index.test.tsx (ran the frontend unit suite: 263 files, 1007 tests)
- bash ./scripts/check-published-package-version-discipline.sh
- git diff --check