### PR TITLE
chore(ci): accept pnpm delimiter in postgres image smoke

### DIFF
--- a/scripts/e2e-smoke-postgres-images.sh
+++ b/scripts/e2e-smoke-postgres-images.sh
@@ -23,6 +23,9 @@ fi
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --)
+      shift
+      ;;
     --env-file)
       ENV_FILE="$2"
       shift 2


### PR DESCRIPTION
## Summary
- allow the Postgres image smoke script to ignore the npm/pnpm argument delimiter forwarded as a literal `--`
- fixes the structural failure seen in the Docker Images v0.10.1 release smoke job

## Verification
- `bash -n scripts/e2e-smoke-postgres-images.sh`
- `pnpm run test:e2e:smoke:postgres:images -- --env-file /tmp/enterpriseglue-nonexistent.env --project-name parser-test` now reaches env-file validation instead of failing on unknown `--`
- `git diff --check`