### PR TITLE
fix(security): upgrade vulnerable backend dependencies

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -55,7 +55,7 @@
     "sql.js": "^1.13.0",
     "swagger-ui-express": "^5.0.0",
     "typeorm": "^0.3.29",
-    "undici": "^7.28.0",
+    "undici": "^7.29.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/packages/backend-host/package.json
+++ b/packages/backend-host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@enterpriseglue/backend-host",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "OSS backend host for EnterpriseGlue — Express app, route modules, enterprise loader, and server bootstrap",
   "license": "Apache-2.0",
   "repository": {
@@ -29,7 +29,7 @@
     "swagger-ui-express": "^5.0.1",
     "typeorm": "^0.3.29",
     "typescript": "^5.8.3",
-    "undici": "^7.28.0",
+    "undici": "^7.29.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@enterpriseglue/shared",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Shared utilities, contracts, and services for EnterpriseGlue",
   "license": "Apache-2.0",
   "repository": {
@@ -40,7 +40,7 @@
     "express": "^5.2.1",
     "express-rate-limit": "^8.2.1",
     "google-auth-library": "^10.6.2",
-    "ip-address": ">=10.1.1",
+    "ip-address": "^10.4.0",
     "helmet": "^8.1.0",
     "jsonwebtoken": "^9.0.2",
     "nodemailer": "^9.0.1",
@@ -50,7 +50,7 @@
     "reflect-metadata": "^0.2.2",
     "resend": "^6.12.2",
     "typeorm": "^0.3.29",
-    "undici": "^7.28.0",
+    "undici": "^7.29.0",
     "uuid": "^14.0.0",
     "zod": "^4.3.6"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,13 +12,14 @@ overrides:
   esbuild: ^0.28.1
   form-data: ^4.0.6
   immutable: ^5.1.9
+  ip-address: ^10.4.0
   morgan: ^1.11.0
   nodemailer: ^9.0.1
   postcss: ^8.5.25
   qs: ^6.15.2
   tar: ^7.5.19
   typeorm: ^0.3.31
-  undici: ^7.28.0
+  undici: ^7.29.0
 
 importers:
 
@@ -146,8 +147,8 @@ importers:
         specifier: ^0.3.31
         version: 0.3.31(babel-plugin-macros@3.1.0)(mssql@12.7.0(supports-color@7.2.0))(mysql2@3.23.2(@types/node@25.6.1))(oracledb@6.10.0)(pg@8.20.0)(sql.js@1.14.1)(supports-color@7.2.0)
       undici:
-        specifier: ^7.28.0
-        version: 7.28.0
+        specifier: ^7.29.0
+        version: 7.29.0
       zod:
         specifier: ^4.3.6
         version: 4.4.3
@@ -394,8 +395,8 @@ importers:
         specifier: ^5.8.3
         version: 5.9.3
       undici:
-        specifier: ^7.28.0
-        version: 7.28.0
+        specifier: ^7.29.0
+        version: 7.29.0
       zod:
         specifier: ^4.3.6
         version: 4.4.3
@@ -584,8 +585,8 @@ importers:
         specifier: ^8.1.0
         version: 8.1.0
       ip-address:
-        specifier: '>=10.1.1'
-        version: 10.2.0
+        specifier: ^10.4.0
+        version: 10.4.0
       jsonwebtoken:
         specifier: ^9.0.2
         version: 9.0.3
@@ -611,8 +612,8 @@ importers:
         specifier: ^0.3.31
         version: 0.3.31(babel-plugin-macros@3.1.0)(mssql@12.7.0(supports-color@7.2.0))(mysql2@3.23.2(@types/node@25.6.1))(oracledb@6.10.0)(pg@8.20.0)(sql.js@1.14.1)(supports-color@7.2.0)
       undici:
-        specifier: ^7.28.0
-        version: 7.28.0
+        specifier: ^7.29.0
+        version: 7.29.0
       uuid:
         specifier: ^14.0.0
         version: 14.0.0
@@ -3531,8 +3532,8 @@ packages:
   iobuffer@5.4.0:
     resolution: {integrity: sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==}
 
-  ip-address@10.2.0:
-    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+  ip-address@10.4.0:
+    resolution: {integrity: sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -4811,8 +4812,8 @@ packages:
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   universal-github-app-jwt@2.2.2:
@@ -8157,7 +8158,7 @@ snapshots:
   express-rate-limit@8.5.1(express@5.2.1(supports-color@7.2.0)):
     dependencies:
       express: 5.2.1(supports-color@7.2.0)
-      ip-address: 10.2.0
+      ip-address: 10.4.0
 
   express@5.2.1(supports-color@7.2.0):
     dependencies:
@@ -8534,7 +8535,7 @@ snapshots:
 
   iobuffer@5.4.0: {}
 
-  ip-address@10.2.0: {}
+  ip-address@10.4.0: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -8636,7 +8637,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.28.0
+      undici: 7.29.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -9800,7 +9801,7 @@ snapshots:
 
   undici-types@7.19.2: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   universal-github-app-jwt@2.2.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,13 +14,14 @@ overrides:
   esbuild: ^0.28.1
   form-data: ^4.0.6
   immutable: ^5.1.9
+  ip-address: ^10.4.0
   morgan: ^1.11.0
   nodemailer: ^9.0.1
   postcss: ^8.5.25
   qs: ^6.15.2
   tar: ^7.5.19
   typeorm: ^0.3.31
-  undici: ^7.28.0
+  undici: ^7.29.0
 allowBuilds:
   '@carbon/charts': true
   '@carbon/charts-react': true


### PR DESCRIPTION
## Summary

- Upgrade `undici` from 7.28.0 to 7.29.0 across the backend workspace.
- Upgrade `ip-address` from 10.2.0 to 10.4.0 and enforce the fixed version through the workspace override.
- Bump `@enterpriseglue/backend-host` to 0.2.11 and `@enterpriseglue/shared` to 0.3.7.
- Regenerate the pnpm lockfile with a minimal dependency-only diff.

## Why

The Docker Images workflow for the v0.10.6 release published and smoke-tested the images successfully, but the published backend security scan failed after a newer Trivy database detected vulnerabilities in `undici@7.28.0` and `ip-address@10.2.0`.

This resolves CVE-2026-13697, CVE-2026-69192, CVE-2026-54272, CVE-2026-69198, and the associated medium-severity undici advisories reported by that scan.

## Compatibility

- Both upgrades stay within the existing dependency major versions.
- No public API, OpenAPI, configuration, database migration, UI, authentication, or authorization code changes.
- No changes to the SSO worktree.
- Node compatibility remains aligned with the repository Node 24 runtime.

## Verification

- Frozen install with pnpm 11.0.8.
- Backend unit tests: 240 files and 722 tests passed.
- Frontend TypeScript check passed.
- Shared and backend-host builds passed.
- Backend typecheck passed.
- OSS/EE boundary guard passed.
- Third-party license check passed with notices unchanged.
- Production backend Docker image built successfully.
- Fresh Trivy database scan of that image: 0 UNKNOWN, LOW, MEDIUM, HIGH, or CRITICAL vulnerabilities.

## Release and rollback

This is a patch-level security fix and is labeled `release:fix`. Expected next version: `v0.10.7` through Release Please. Rollback is a normal revert of this commit followed by an image rebuild, although doing so would reintroduce the reported vulnerable dependency versions.