### PR TITLE
fix(release): qualify 0.11.1 image smoke

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -123,6 +123,10 @@ jobs:
             echo "ADMIN_EMAIL=admin@enterpriseglue.ai"
             echo "ADMIN_PASSWORD=change_me_change_me"
             echo "ENCRYPTION_KEY=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+            echo "EG_ENGINE_ALLOWED_HOSTS=camunda-mock"
+            echo "EG_ENGINE_ALLOW_PRIVATE_HOSTS=true"
+            echo "EG_ALLOW_INSECURE_ENGINE_HTTP=true"
+            echo "EG_ENFORCE_ENGINE_ENDPOINT_POLICY=true"
             echo "GIT_REPOS_PATH=./data/repos"
             echo "GIT_DEFAULT_BRANCH=main"
             echo "API_BASE_URL="
@@ -157,6 +161,9 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
         run: pnpm install --frozen-lockfile
+
+      - name: Build shared test dependencies
+        run: pnpm run build:shared
 
       - name: Resolve Playwright runner image
         id: playwright-runner

--- a/.release-notes/release-image-smoke-runtime-actions.json
+++ b/.release-notes/release-image-smoke-runtime-actions.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "./schema.json",
+  "schemaVersion": 1,
+  "id": "release-image-smoke-runtime-actions",
+  "type": "fix",
+  "scope": "mission-control-and-release-qualification",
+  "breaking": false,
+  "audiences": [
+    "users",
+    "operators",
+    "developers",
+    "security"
+  ],
+  "summary": "Restores Mission Control decision access for authorized users and makes the published-image Postgres smoke lane self-contained and reproducible.",
+  "userImpact": [
+    "Users with engine instance-view permission can open Mission Control Decisions when the runtime action is intentionally omitted from the coarse frontend availability snapshot.",
+    "Release operators receive a complete Postgres image-smoke result instead of a missing shared-build artifact failure."
+  ],
+  "upgrade": {
+    "required": false,
+    "instructions": [
+      "Upgrade the frontend and backend images together to 0.11.1 to receive the corrected Decisions authorization experience and retained release qualification."
+    ]
+  },
+  "configuration": [],
+  "api": {
+    "compatibility": "none",
+    "changes": []
+  },
+  "database": {
+    "migrations": [],
+    "rollbackSupported": true,
+    "notes": [
+      "This hotfix does not change the database schema or migration sequence."
+    ]
+  },
+  "security": [
+    "The frontend falls back only to the server-issued permission snapshot when no explicit action-availability decision exists; backend runtime-resource authorization remains authoritative on every request.",
+    "The release smoke runner passes its existing test encryption key into the isolated Playwright process and keeps production engine endpoint enforcement enabled with an exact private mock-host allowlist.",
+    "Historical generic-private-key alerts referenced test-only SAML fixtures that were already replaced by runtime-generated one-day ephemeral keys; the alerts are resolved as used in tests without rewriting release history."
+  ],
+  "documentation": [
+    "The versioned release notes describe the corrected Mission Control authorization fallback and published-image qualification boundary."
+  ],
+  "knownLimitations": [],
+  "rollback": [
+    "Revert to the matching 0.11.0 frontend and backend images if necessary; Mission Control Decisions may again show a false missing-permission notice for otherwise authorized users."
+  ],
+  "validation": [
+    "Run the frontend authorization helper regression covering a runtime-enforced action omitted from action availability.",
+    "Run the Docker security workflow contract tests and build the shared test dependencies before the published-image smoke.",
+    "Run the Mission Control Postgres image smoke against the exact candidate images and require every browser journey to pass.",
+    "Verify GitHub reports no open generic secret-scanning alerts for the repository."
+  ],
+  "packages": [
+    {
+      "name": "@enterpriseglue/frontend-host",
+      "previousVersion": "0.4.8",
+      "newVersion": "0.4.9",
+      "impact": "patch"
+    }
+  ]
+}

--- a/frontend/__tests__/src/shared/auth/permissions.test.ts
+++ b/frontend/__tests__/src/shared/auth/permissions.test.ts
@@ -206,4 +206,30 @@ describe('frontend permission helpers', () => {
       { type: 'engine', id: 'engine-1' },
     ).allowed).toBe(true);
   });
+
+  it('falls back to engine permissions for runtime-enforced actions omitted from availability', () => {
+    const decision = evaluateActionSnapshot(
+      {
+        ...baseSnapshot,
+        engines: [{
+          resourceId: 'engine-1',
+          permissions: [EnginePermission.INSTANCE_VIEW],
+          runtimePermissions: [],
+          actionAvailability: {
+            allowedActions: [],
+            restrictions: {},
+          },
+        }],
+      },
+      'engine.runtime.decisions.read',
+      { type: 'engine', id: 'engine-1' },
+    );
+
+    expect(decision).toMatchObject({
+      allowed: true,
+      permissionId: EnginePermission.INSTANCE_VIEW,
+      reason: 'Allowed by current permission snapshot',
+      resourceId: 'engine-1',
+    });
+  });
 });

--- a/packages/frontend-host/package.json
+++ b/packages/frontend-host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@enterpriseglue/frontend-host",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "OSS frontend host for EnterpriseGlue — routes, enterprise loader, extension registry, and feature components",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/frontend-host/src/shared/auth/guards.tsx
+++ b/packages/frontend-host/src/shared/auth/guards.tsx
@@ -123,8 +123,16 @@ export function evaluateActionSnapshot(
         ? snapshot?.engines.find((item) => item.resourceId === resourceId)?.actionAvailability
         : undefined;
 
-  if (availability) {
-    const restriction = availability.restrictions[actionId];
+  const restriction = availability?.restrictions[actionId];
+  const hasExplicitAvailabilityDecision = Boolean(
+    availability && (availability.allowedActions.includes(actionId) || restriction),
+  );
+  // Runtime-enforced actions are deliberately omitted from the coarse
+  // frontend availability snapshot. Only treat availability as authoritative
+  // when the server explicitly allowed or restricted this action; otherwise
+  // fall through to the permission snapshot and let the guarded backend route
+  // enforce any runtime-resource boundary.
+  if (availability && hasExplicitAvailabilityDecision) {
     allowed = availability.allowedActions.includes(actionId);
     return {
       actionId,

--- a/scripts/e2e-smoke-postgres-images.sh
+++ b/scripts/e2e-smoke-postgres-images.sh
@@ -146,6 +146,7 @@ run_playwright_smoke() {
       -e E2E_ADMIN_EMAIL \
       -e E2E_ADMIN_PASSWORD \
       -e E2E_REQUIRE_MISSION_CONTROL_MOCK \
+      -e ENCRYPTION_KEY \
       -v "$ROOT_DIR:/work" \
       -w /work \
       "$PLAYWRIGHT_RUNNER_IMAGE" \
@@ -195,7 +196,7 @@ main() {
   FRONTEND_PORT="$(choose_port 8080 18080 28080)"
   POSTGRES_HOST_PORT="$(choose_port 55432 65432 75432)"
 
-  local postgres_user postgres_password postgres_database postgres_schema postgres_ssl admin_email admin_password
+  local postgres_user postgres_password postgres_database postgres_schema postgres_ssl admin_email admin_password encryption_key
   postgres_user="$(env_first POSTGRES_USER)"
   postgres_password="$(env_first POSTGRES_PASSWORD)"
   postgres_database="$(env_first POSTGRES_DATABASE POSTGRES_DB)"
@@ -203,6 +204,7 @@ main() {
   postgres_ssl="$(env_first POSTGRES_SSL)"
   admin_email="$(env_first ADMIN_EMAIL)"
   admin_password="$(env_first ADMIN_PASSWORD)"
+  encryption_key="$(env_first ENCRYPTION_KEY)"
 
   [[ -n "$postgres_user" ]] || error "POSTGRES_USER missing in $ENV_FILE"
   [[ -n "$postgres_password" ]] || error "POSTGRES_PASSWORD missing in $ENV_FILE"
@@ -210,6 +212,7 @@ main() {
   [[ -n "$postgres_schema" ]] || error "POSTGRES_SCHEMA missing in $ENV_FILE"
   [[ -n "$admin_email" ]] || error "ADMIN_EMAIL missing in $ENV_FILE"
   [[ -n "$admin_password" ]] || error "ADMIN_PASSWORD missing in $ENV_FILE"
+  [[ -n "$encryption_key" ]] || error "ENCRYPTION_KEY missing in $ENV_FILE"
 
   log "Starting Postgres db/backend services with Mission Control mock"
   FRONTEND_HOST_PORT="$FRONTEND_PORT" \
@@ -246,6 +249,7 @@ main() {
   E2E_ADMIN_EMAIL="$admin_email" \
   E2E_ADMIN_PASSWORD="$admin_password" \
   E2E_REQUIRE_MISSION_CONTROL_MOCK=true \
+  ENCRYPTION_KEY="$encryption_key" \
   run_playwright_smoke
 
   log "Mission Control image smoke tests passed"

--- a/scripts/security-workflow-contract.test.mjs
+++ b/scripts/security-workflow-contract.test.mjs
@@ -14,6 +14,14 @@ const imagePublish = readFileSync(
   new URL('../.github/workflows/docker-images-reusable.yml', import.meta.url),
   'utf8',
 );
+const dockerImages = readFileSync(
+  new URL('../.github/workflows/docker-images.yml', import.meta.url),
+  'utf8',
+);
+const postgresImageSmoke = readFileSync(
+  new URL('./e2e-smoke-postgres-images.sh', import.meta.url),
+  'utf8',
+);
 
 test('nightly preserves evidence before enforcing the high and critical gate', () => {
   assert.match(nightly, /echo "critical=\$\{critical_total\}"/);
@@ -55,4 +63,24 @@ test('image publishing labels and verifies source, revision, and version', () =>
   assert.match(imagePublish, /EXPECTED_REVISION: \$\{\{ github\.sha \}\}/);
   assert.match(imagePublish, /EXPECTED_VERSION: \$\{\{ steps\.meta\.outputs\.image_tag \}\}/);
   assert.match(imagePublish, /verify-oci-image-metadata\.mjs "\$prefix"/);
+});
+
+test('published Postgres image smoke compiles test dependencies and preserves fail-closed engine policy', () => {
+  const install = dockerImages.indexOf('- name: Install dependencies');
+  const buildShared = dockerImages.indexOf('- name: Build shared test dependencies');
+  const smoke = dockerImages.indexOf('- name: Run Mission Control Playwright smoke on Postgres images');
+  assert.ok(install >= 0 && install < buildShared, 'shared test dependencies must build after install');
+  assert.ok(buildShared < smoke, 'shared test dependencies must build before Playwright starts');
+  assert.match(dockerImages, /run: pnpm run build:shared/);
+  assert.match(dockerImages, /echo "EG_ENGINE_ALLOWED_HOSTS=camunda-mock"/);
+  assert.match(dockerImages, /echo "EG_ENGINE_ALLOW_PRIVATE_HOSTS=true"/);
+  assert.match(dockerImages, /echo "EG_ALLOW_INSECURE_ENGINE_HTTP=true"/);
+  assert.match(dockerImages, /echo "EG_ENFORCE_ENGINE_ENDPOINT_POLICY=true"/);
+});
+
+test('published Postgres image smoke passes the configured encryption boundary into Playwright', () => {
+  assert.match(postgresImageSmoke, /encryption_key="\$\(env_first ENCRYPTION_KEY\)"/);
+  assert.match(postgresImageSmoke, /\[\[ -n "\$encryption_key" \]\] \|\| error "ENCRYPTION_KEY missing in \$ENV_FILE"/);
+  assert.match(postgresImageSmoke, /-e ENCRYPTION_KEY \\/);
+  assert.match(postgresImageSmoke, /ENCRYPTION_KEY="\$encryption_key" \\/);
 });


### PR DESCRIPTION
## Summary

- restore authorized Mission Control decision access when runtime-enforced actions are intentionally absent from coarse availability
- make the published Postgres image smoke self-contained by building shared test dependencies and passing required encryption/engine-policy settings
- record the 0.11.1 patch impact; GitHub generic-private-key alerts #2 and #3 are resolved as historical test fixtures already replaced by ephemeral runtime keys

## Validation

- root TypeScript typecheck
- frontend authorization helper: 9/9
- security workflow contracts: 5/5
- release-note contracts: 22/22
- release-note validation and 0.11.1 assertion
- exact local candidate images against PostgreSQL: Mission Control smoke 5/5
- open generic private-key secret-scanning alerts: 0