### PR TITLE
fix(release): refresh moving release notes ref

### DIFF
--- a/.release-notes/release-image-smoke-runtime-actions.json
+++ b/.release-notes/release-image-smoke-runtime-actions.json
@@ -11,10 +11,11 @@
     "developers",
     "security"
   ],
-  "summary": "Restores Mission Control decision access for authorized users and makes the published-image Postgres smoke lane self-contained and reproducible.",
+  "summary": "Restores Mission Control decision access for authorized users and makes published-image and hotfix-release qualification self-contained and reproducible.",
   "userImpact": [
     "Users with engine instance-view permission can open Mission Control Decisions when the runtime action is intentionally omitted from the coarse frontend availability snapshot.",
-    "Release operators receive a complete Postgres image-smoke result instead of a missing shared-build artifact failure."
+    "Release operators receive a complete Postgres image-smoke result instead of a missing shared-build artifact failure.",
+    "Hotfix release-note preparation safely refreshes a Release Please branch that advanced after workflow checkout."
   ],
   "upgrade": {
     "required": false,
@@ -49,6 +50,7 @@
   "validation": [
     "Run the frontend authorization helper regression covering a runtime-enforced action omitted from action availability.",
     "Run the Docker security workflow contract tests and build the shared test dependencies before the published-image smoke.",
+    "Run the release-note contracts and verify preparation force-refreshes only the validated Release Please branch ref.",
     "Run the Mission Control Postgres image smoke against the exact candidate images and require every browser journey to pass.",
     "Verify GitHub reports no open generic secret-scanning alerts for the repository."
   ],

--- a/scripts/prepare-release-notes-pr.sh
+++ b/scripts/prepare-release-notes-pr.sh
@@ -22,7 +22,7 @@ if [[ ! "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
 fi
 
 git fetch --no-tags origin \
-  "refs/heads/${RELEASE_PR_HEAD_REF}:refs/remotes/origin/${RELEASE_PR_HEAD_REF}"
+  "+refs/heads/${RELEASE_PR_HEAD_REF}:refs/remotes/origin/${RELEASE_PR_HEAD_REF}"
 git checkout -B "$RELEASE_PR_HEAD_REF" "origin/$RELEASE_PR_HEAD_REF"
 
 base_tag="$(git tag --list 'v*' --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)"

--- a/scripts/release-notes.test.mjs
+++ b/scripts/release-notes.test.mjs
@@ -249,10 +249,16 @@ test('expensive pull-request workflows cannot start before release-note prefligh
 test('normal and hotfix release workflows generate detailed notes through the same script', () => {
   const release = readFileSync(new URL('../.github/workflows/release-please.yml', import.meta.url), 'utf8')
   const hotfix = readFileSync(new URL('../.github/workflows/release-hotfix.yml', import.meta.url), 'utf8')
+  const prepare = readFileSync(new URL('./prepare-release-notes-pr.sh', import.meta.url), 'utf8')
   for (const workflow of [release, hotfix]) {
     assert.match(workflow, /node scripts\/release-notes\.mjs baseline/)
     assert.match(workflow, /bash scripts\/prepare-release-notes-pr\.sh/)
   }
+  assert.match(
+    prepare,
+    /"\+refs\/heads\/\$\{RELEASE_PR_HEAD_REF\}:refs\/remotes\/origin\/\$\{RELEASE_PR_HEAD_REF\}"/,
+    'release-note preparation must refresh the validated moving Release Please ref',
+  )
   assert.match(release, /gh release edit "v\$\{RELEASE_VERSION\}" --notes-file/)
   assert.match(release, /baseline --allow-pending/)
   assert.equal((release.match(/\^chore\\\(main\\\)!\?: release/g) || []).length, 2)


### PR DESCRIPTION
## Summary

- force-refresh only the validated Release Please remote-tracking ref before preparing detailed notes
- prevent a non-fast-forward fetch failure when Release Please advances the branch after workflow checkout
- cover the fetch contract and include the repair in the 0.11.1 release fragment

## Validation

- release-note contracts: 22/22
- release-note validation
- forced version assertion: 0.11.1
- shell syntax check