### PR TITLE
chore(community): enable OSS issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -3,6 +3,7 @@ description: Report a reproducible problem
 title: "[Bug]: "
 labels:
   - bug
+type: Bug
 body:
   - type: markdown
     attributes:
@@ -59,7 +60,7 @@ body:
     attributes:
       label: Version
       description: Release tag/commit SHA, or "main".
-      placeholder: "v0.1.0" or "main" or commit SHA
+      placeholder: "v0.1.0, main, or commit SHA"
     validations:
       required: false
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Questions & discussions
-    url: https://github.com/haryselman/enterpriseglue/discussions
+    url: https://github.com/EnterpriseGlue/enterpriseglue-the-bridge-oss/discussions
     about: Please use GitHub Discussions for questions, troubleshooting, and design discussion.
-  - name: Security vulnerability report
-    url: https://github.com/haryselman/enterpriseglue/security/advisories/new
-    about: Please report security vulnerabilities via GitHub Security Advisories (preferred).

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,49 @@
+name: Documentation improvement
+description: Report missing, unclear, or incorrect documentation
+title: "[Docs]: "
+labels:
+  - documentation
+type: Task
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping us improve the EnterpriseGlue documentation.
+
+        For questions and troubleshooting, please use GitHub Discussions.
+
+  - type: input
+    id: location
+    attributes:
+      label: Documentation location
+      description: Link to the affected page or provide the relevant file path.
+      placeholder: "https://... or docs/path/to/file.md"
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What needs improvement?
+      description: Describe what is missing, unclear, outdated, or incorrect.
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested improvement
+      description: Describe the change you would like to see.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: willingness
+    attributes:
+      label: Are you willing to contribute a PR?
+      options:
+        - "Yes"
+        - Maybe
+        - "No"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -3,6 +3,7 @@ description: Suggest an idea or enhancement
 title: "[Feature]: "
 labels:
   - enhancement
+type: Feature
 body:
   - type: markdown
     attributes:
@@ -53,8 +54,8 @@ body:
     attributes:
       label: Are you willing to contribute a PR?
       options:
-        - Yes
+        - "Yes"
         - Maybe
-        - No
+        - "No"
     validations:
       required: false


### PR DESCRIPTION
## Summary

Enable the OSS community contribution paths by repairing the existing issue forms, adding a documentation form, and routing questions to the repository Discussions area.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Docs
- [ ] Refactor
- [x] Internal repository maintenance

## How to test

- [x] Parse every `.github/ISSUE_TEMPLATE/*.yml` file as YAML.
- [x] Validate required form keys, unique IDs and labels, and string dropdown options.
- [x] Confirm referenced labels (`bug`, `enhancement`, `documentation`) exist.
- [x] Confirm referenced issue types (`Bug`, `Feature`, `Task`) are enabled.
- [x] Run `pnpm run release-notes:validate` with the internal-change exemption.
- [x] Run `pnpm run release-notes:preflight -- --base-ref origin/main` with the internal-change exemption.

## Release impact

- Release-note fragment: none
- Expected application bump: none
- Compatibility: backward-compatible
- Required operator action: none
- Release-note exemption: GitHub community-health metadata only; no user, operator, API, database, package, or security behavior changes.

Release-note exemption: GitHub community-health metadata only; no user, operator, API, database, package, or security behavior changes.

## Checklist

- [x] I have kept the PR focused and scoped
- [x] PR title follows release format
- [x] I have added or updated validation where appropriate
- [x] I have updated documentation where appropriate
- [x] I have added a release label
- [x] I documented an allowed `release-note:none` exemption
- [x] I confirmed release impact is none
- [x] I have not included secrets in code or logs

## Related issues

Community report that OSS only offered security reporting and that Discussions was disabled.
