### PR TITLE
chore(ci): preserve release please metadata

### DIFF
--- a/.github/workflows/release-hotfix.yml
+++ b/.github/workflows/release-hotfix.yml
@@ -34,6 +34,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN != '' && secrets.RELEASE_PLEASE_TOKEN || github.token }}
 
       - name: Setup Node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN != '' && secrets.RELEASE_PLEASE_TOKEN || github.token }}
 
       - name: Setup Node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0

--- a/docs/development/release-notes-process.md
+++ b/docs/development/release-notes-process.md
@@ -94,7 +94,8 @@ release pull request. The workflow then:
 1. validates that the manifest, latest stable tag, and changelog agree;
 2. finds all fragments changed since the latest stable tag;
 3. generates `docs/releases/vX.Y.Z.md` on the Release Please branch;
-4. copies that document into the release pull-request body; and
+4. synchronizes that document to a managed release pull-request comment while
+   preserving Release Please's machine-readable pull-request body; and
 5. publishes the same document as the GitHub release body after the release
    pull request is merged.
 

--- a/scripts/prepare-release-notes-pr.sh
+++ b/scripts/prepare-release-notes-pr.sh
@@ -48,9 +48,26 @@ if ! git diff --cached --quiet; then
   git push origin "HEAD:refs/heads/${RELEASE_PR_HEAD_REF}"
 fi
 
-gh api \
-  --method PATCH \
-  "repos/${GITHUB_REPOSITORY}/pulls/${RELEASE_PR_NUMBER}" \
-  -f "body=$(<"$release_file")" >/dev/null
+comment_marker='<!-- enterpriseglue-detailed-release-notes -->'
+comment_body="${comment_marker}
 
-echo "Detailed release notes prepared in ${release_file} and copied to PR #${RELEASE_PR_NUMBER}."
+$(<"$release_file")"
+comment_id="$(gh api \
+  --paginate \
+  "repos/${GITHUB_REPOSITORY}/issues/${RELEASE_PR_NUMBER}/comments" \
+  --jq ".[] | select(.body | startswith(\"${comment_marker}\")) | .id" \
+  | head -n 1)"
+
+if [[ -n "$comment_id" ]]; then
+  gh api \
+    --method PATCH \
+    "repos/${GITHUB_REPOSITORY}/issues/comments/${comment_id}" \
+    -f "body=${comment_body}" >/dev/null
+else
+  gh api \
+    --method POST \
+    "repos/${GITHUB_REPOSITORY}/issues/${RELEASE_PR_NUMBER}/comments" \
+    -f "body=${comment_body}" >/dev/null
+fi
+
+echo "Detailed release notes prepared in ${release_file} and synchronized to the managed PR comment for #${RELEASE_PR_NUMBER}."

--- a/scripts/release-notes.test.mjs
+++ b/scripts/release-notes.test.mjs
@@ -253,6 +253,11 @@ test('normal and hotfix release workflows generate detailed notes through the sa
   for (const workflow of [release, hotfix]) {
     assert.match(workflow, /node scripts\/release-notes\.mjs baseline/)
     assert.match(workflow, /bash scripts\/prepare-release-notes-pr\.sh/)
+    assert.match(
+      workflow,
+      /uses: actions\/checkout@[^\n]+\n\s+with:\n\s+fetch-depth: 0\n\s+token: \$\{\{ secrets\.RELEASE_PLEASE_TOKEN != '' && secrets\.RELEASE_PLEASE_TOKEN \|\| github\.token \}\}/,
+      'release workflows must persist the trusted release token for release-note branch pushes',
+    )
   }
   assert.match(
     prepare,

--- a/scripts/release-notes.test.mjs
+++ b/scripts/release-notes.test.mjs
@@ -264,6 +264,13 @@ test('normal and hotfix release workflows generate detailed notes through the sa
     /"\+refs\/heads\/\$\{RELEASE_PR_HEAD_REF\}:refs\/remotes\/origin\/\$\{RELEASE_PR_HEAD_REF\}"/,
     'release-note preparation must refresh the validated moving Release Please ref',
   )
+  assert.match(prepare, /enterpriseglue-detailed-release-notes/)
+  assert.match(prepare, /issues\/\$\{RELEASE_PR_NUMBER\}\/comments/)
+  assert.doesNotMatch(
+    prepare,
+    /repos\/\$\{GITHUB_REPOSITORY\}\/pulls\/\$\{RELEASE_PR_NUMBER\}/,
+    'detailed notes must not replace Release Please machine-readable PR metadata',
+  )
   assert.match(release, /gh release edit "v\$\{RELEASE_VERSION\}" --notes-file/)
   assert.match(release, /baseline --allow-pending/)
   assert.equal((release.match(/\^chore\\\(main\\\)!\?: release/g) || []).length, 2)


### PR DESCRIPTION
## Summary

Keep both normal and hotfix Release Please automation attributable to the trusted release identity, and preserve Release Please's machine-readable pull-request body. Detailed generated notes are now synchronized idempotently to a managed PR comment instead of replacing the canonical body.

This prevents two failure modes observed on release 0.12.0: first-time-contributor workflow approval for github-actions[bot], and failure to recognize a merged Release Please PR during publication.

## How to test

- node --test scripts/release-notes.test.mjs
- pnpm run release-notes:validate
- pnpm run release-notes:preflight -- --base-ref origin/main with the documented internal exemption context
- git diff --check

## Release impact

- Expected application bump: none
- Compatibility: backward-compatible
- Required operator action: none

Release-note exemption: internal release automation credential routing and metadata preservation only; no user, operator, API, database, package, or security behavior changes.

## Checklist

- [x] Focused and scoped
- [x] Contract tests added
- [x] Release process documentation updated
- [x] Release metadata validated
- [x] No secrets added to code or logs